### PR TITLE
Some fixes

### DIFF
--- a/cinnabar/arsenic.py
+++ b/cinnabar/arsenic.py
@@ -39,8 +39,8 @@ if __name__ == "__main__":
     if "network" in args.plot:
         network.draw_graph(title=args.title, filename=f"{args.prefix}network.png")
     if "ddg" in args.plot:
-        plotting.plot_DDGs(network.results, title=args.title, filename=f"{args.prefix}DDGs.png")
+        plotting.plot_DDGs(network.graph, title=args.title, filename=f"{args.prefix}DDGs.png")
     if "dg" in args.plot:
         plotting.plot_DGs(network.graph, title=args.title, filename=f"{args.prefix}DGs.png")
     if "all ddg" in args.plot:
-        plotting.plot_all_DDGs(network.graph, title=args.title, filename=f"{args.prefix}DGs.png")
+        plotting.plot_all_DDGs(network.graph, title=args.title, filename=f"{args.prefix}all_DDGs.png")

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -419,6 +419,7 @@ def plot_all_DDGs(
     title: str = "",
     filename: Union[str, None] = None,
     plotly: bool = False,
+    shift: float = 0.0,
     **kwargs,
 ):
     """Plots relative free energies between all ligands, which is calculated from
@@ -438,6 +439,8 @@ def plot_all_DDGs(
         filename for plot
     plotly : bool, default = True
         whether to use plotly for the plotting
+    shift : float, default = 0.
+        shift both the x and y axis by a constant
 
     Returns
     -------

--- a/cinnabar/wrangle.py
+++ b/cinnabar/wrangle.py
@@ -66,7 +66,6 @@ class FEMap(object):
     def __init__(self, csv):
         self.results = read_csv(csv)
         self.graph = nx.DiGraph()
-        self.n_edges = len(self.results)
 
         self.generate_graph_from_results()
 
@@ -106,7 +105,8 @@ class FEMap(object):
             edge[2]["exp_dDDG"] = (dDG_A**2 + dDG_B**2) ** 0.5
 
         self.n_ligands = self.graph.number_of_nodes()
-        self.degree = self.graph.number_of_edges() / self.n_ligands
+        self.n_edges = self.graph.number_of_edges() 
+        self.degree = self.n_edges / self.n_ligands
 
         # check the graph has minimal connectivity
         self.check_weakly_connected()


### PR DESCRIPTION
Hello! I've been using cinnabar and have noticed some small fixes:

[1.](https://github.com/annamherz/cinnabar/blob/20fa6cb8b98bf56265e87eea51e4be8db811d3b9/cinnabar/arsenic.py#L42) If this is not `network.graph` it isn't able to plot.

[2.](https://github.com/annamherz/cinnabar/blob/20fa6cb8b98bf56265e87eea51e4be8db811d3b9/cinnabar/plotting.py#L422) Similarly here, without `shift` the function does not work. I've added it in but I guess it could also be removed from [the end](https://github.com/annamherz/cinnabar/blob/20fa6cb8b98bf56265e87eea51e4be8db811d3b9/cinnabar/plotting.py#L501) instead for it to be able to proceed.

[3.] `self.n_edges = len(self.results)` always returns two, as the length of the dictionary returned by the `read_csv` function is two. I think [this here](https://github.com/annamherz/cinnabar/blob/20fa6cb8b98bf56265e87eea51e4be8db811d3b9/cinnabar/wrangle.py#L108) would be better to get the actual number of edges in the network?

Thank you!

