### PR TITLE
Update how RMSE and MUE (and their CIs) are computed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           pytest -v --cov=cinnabar --cov-report=xml --cov-report=term --color=yes cinnabar/tests/
       - uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)

--- a/cinnabar/plotlying.py
+++ b/cinnabar/plotlying.py
@@ -274,8 +274,8 @@ def _master_plot(
                                         xerr,
                                         yerr,
                                         statistic=statistic,
-                                        bootstrap_true_uncertainty=bootstrap_x_uncertainty,
-                                        bootstrap_pred_uncertainty=bootstrap_y_uncertainty)
+                                        include_true_uncertainty=bootstrap_x_uncertainty,
+                                        include_pred_uncertainty=bootstrap_y_uncertainty)
 
         statistic_type = 'mean' if bootstrap_x_uncertainty or bootstrap_y_uncertainty else 'mle'
         string.append(

--- a/cinnabar/plotlying.py
+++ b/cinnabar/plotlying.py
@@ -160,6 +160,7 @@ def _master_plot(
     filename: Optional[str] = None,
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool = False,
+    statistic_type: str = "mle",
 ):
     nsamples = len(x)
     ax_min = min(min(x), min(y)) - 0.5
@@ -268,6 +269,8 @@ def _master_plot(
 
     # stats and title
     string = []
+    if statistic_type not in ['mle', 'mean']:
+        raise Exception(f"Unknown statistic type {statistic_type}")
     for statistic in statistics:
         bss = stats.bootstrap_statistic(x,
                                         y,
@@ -276,8 +279,6 @@ def _master_plot(
                                         statistic=statistic,
                                         include_true_uncertainty=bootstrap_x_uncertainty,
                                         include_pred_uncertainty=bootstrap_y_uncertainty)
-
-        statistic_type = 'mean' if bootstrap_x_uncertainty or bootstrap_y_uncertainty else 'mle'
         string.append(
             f"{statistic + ':':5s}{bss[statistic_type]:5.2f} [95%: {bss['low']:5.2f}, {bss['high']:5.2f}]"
         )

--- a/cinnabar/plotlying.py
+++ b/cinnabar/plotlying.py
@@ -277,8 +277,9 @@ def _master_plot(
                                         bootstrap_true_uncertainty=bootstrap_x_uncertainty,
                                         bootstrap_pred_uncertainty=bootstrap_y_uncertainty)
 
+        statistic_type = 'mean' if bootstrap_x_uncertainty or bootstrap_y_uncertainty else 'mle'
         string.append(
-            f"{statistic + ':':5s}{bss['mean']:5.2f} [95%: {bss['low']:5.2f}, {bss['high']:5.2f}]"
+            f"{statistic + ':':5s}{bss[statistic_type]:5.2f} [95%: {bss['low']:5.2f}, {bss['high']:5.2f}]"
         )
     stats_string = "<br>".join(string)
 

--- a/cinnabar/plotlying.py
+++ b/cinnabar/plotlying.py
@@ -267,10 +267,16 @@ def _master_plot(
     # stats and title
     string = []
     for statistic in statistics:
-        bss = stats.bootstrap_statistic(x, y, statistic=statistic)
+        bss = stats.bootstrap_statistic(x,
+                                        y,
+                                        xerr,
+                                        yerr,
+                                        statistic=statistic,
+                                        bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+                                        bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty)
 
         string.append(
-            f"{statistic + ':':5s}{bss['mle']:5.2f} [95%: {bss['low']:5.2f}, {bss['high']:5.2f}]"
+            f"{statistic + ':':5s}{bss['mean']:5.2f} [95%: {bss['low']:5.2f}, {bss['high']:5.2f}]"
         )
     stats_string = "<br>".join(string)
 

--- a/cinnabar/plotlying.py
+++ b/cinnabar/plotlying.py
@@ -270,7 +270,7 @@ def _master_plot(
     # stats and title
     string = []
     if statistic_type not in ['mle', 'mean']:
-        raise Exception(f"Unknown statistic type {statistic_type}")
+        raise ValueError(f"Unknown statistic type {statistic_type}")
     for statistic in statistics:
         bss = stats.bootstrap_statistic(x,
                                         y,

--- a/cinnabar/plotlying.py
+++ b/cinnabar/plotlying.py
@@ -158,6 +158,8 @@ def _master_plot(
     origins: bool = True,
     statistics: list = ["RMSE", "MUE"],
     filename: Optional[str] = None,
+    bootstrap_x_uncertainty: bool = False,
+    bootstrap_y_uncertainty: bool = False,
 ):
     nsamples = len(x)
     ax_min = min(min(x), min(y)) - 0.5
@@ -272,8 +274,8 @@ def _master_plot(
                                         xerr,
                                         yerr,
                                         statistic=statistic,
-                                        bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-                                        bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty)
+                                        bootstrap_true_uncertainty=bootstrap_x_uncertainty,
+                                        bootstrap_pred_uncertainty=bootstrap_y_uncertainty)
 
         string.append(
             f"{statistic + ':':5s}{bss['mean']:5.2f} [95%: {bss['low']:5.2f}, {bss['high']:5.2f}]"

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -95,7 +95,8 @@ def _master_plot(
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
     statistic_type : str, default 'mle'
-        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
+        the type of statistic to use, either 'mle' (i.e. sample statistic)
+        or 'mean' (i.e. bootstrapped mean statistic)
 
     Returns
     -------
@@ -260,7 +261,8 @@ def plot_DDGs(
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
     statistic_type : str, default 'mle'
-        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
+        the type of statistic to use, either 'mle' (i.e. sample statistic)
+        or 'mean' (i.e. bootstrapped mean statistic)
 
     Returns
     -------
@@ -398,7 +400,8 @@ def plot_DGs(
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
     statistic_type : str, default 'mle'
-        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
+        the type of statistic to use, either 'mle' (i.e. sample statistic)
+        or 'mean' (i.e. bootstrapped mean statistic)
 
     Returns
     -------
@@ -492,7 +495,8 @@ def plot_all_DDGs(
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
     statistic_type : str, default 'mle'
-        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
+        the type of statistic to use, either 'mle' (i.e. sample statistic)
+        or 'mean' (i.e. bootstrapped mean statistic)
 
     Returns
     -------

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -34,6 +34,7 @@ def _master_plot(
     font_sizes: dict = {"title": 12, "labels": 9, "other": 12},
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool = False,
+    statistic_type: str = "mle",
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -93,6 +94,8 @@ def _master_plot(
         whether to account for uncertainty in x when bootstrapping
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
+    statistic_type : str, default 'mle'
+        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
     Returns
     -------
 
@@ -171,6 +174,8 @@ def _master_plot(
 
     # stats and title
     statistics_string = ""
+    if statistic_type not in ['mle', 'mean']:
+        raise Exception(f"Unknown statistic type {statistic_type}")
     for statistic in statistics:
         s = stats.bootstrap_statistic(x,
                                       y,
@@ -179,7 +184,6 @@ def _master_plot(
                                       statistic=statistic,
                                       include_true_uncertainty=bootstrap_x_uncertainty,
                                       include_pred_uncertainty=bootstrap_y_uncertainty)
-        statistic_type = 'mean' if bootstrap_x_uncertainty or bootstrap_y_uncertainty else 'mle'
         string = f"{statistic}:   {s[statistic_type]:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
         statistics_string += string
 
@@ -212,6 +216,7 @@ def plot_DDGs(
     data_label_type: str = None,
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool=False,
+    statistic_type: str = "mle",
     **kwargs,
 ):
     """Function to plot relative free energies
@@ -253,6 +258,8 @@ def plot_DDGs(
         whether to account for uncertainty in x when bootstrapping
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
+    statistic_type : str, default 'mle'
+        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
 
     Returns
     -------
@@ -336,6 +343,7 @@ def plot_DDGs(
             target_name=target_name,
             bootstrap_x_uncertainty=bootstrap_x_uncertainty,
             bootstrap_y_uncertainty=bootstrap_y_uncertainty,
+            statistic_type=statistic_type,
             **kwargs,
         )
     else:
@@ -351,6 +359,7 @@ def plot_DDGs(
             data_labels=data_labels,
             bootstrap_x_uncertainty=bootstrap_x_uncertainty,
             bootstrap_y_uncertainty=bootstrap_y_uncertainty,
+            statistic_type=statistic_type,
             **kwargs,
         )
 
@@ -366,6 +375,7 @@ def plot_DGs(
     shift: float = 0.0,
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool=False,
+    statistic_type: str = "mle",
     **kwargs,
 ):
     """Function to plot absolute free energies.
@@ -386,6 +396,8 @@ def plot_DGs(
         whether to account for uncertainty in x when bootstrapping
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
+    statistic_type : str, default 'mle'
+        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
 
     Returns
     -------
@@ -419,6 +431,7 @@ def plot_DGs(
             filename=filename,
             bootstrap_x_uncertainty=bootstrap_x_uncertainty,
             bootstrap_y_uncertainty=bootstrap_y_uncertainty,
+            statistic_type=statistic_type,
             **kwargs,
         )
     else:
@@ -436,6 +449,7 @@ def plot_DGs(
             filename=filename,
             bootstrap_x_uncertainty=bootstrap_x_uncertainty,
             bootstrap_y_uncertainty=bootstrap_y_uncertainty,
+            statistic_type=statistic_type,
             **kwargs,
         )
 
@@ -450,6 +464,7 @@ def plot_all_DDGs(
     shift: float = 0.0,
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool=False,
+    statistic_type: str = "mle",
     **kwargs,
 ):
     """Plots relative free energies between all ligands, which is calculated from
@@ -475,6 +490,8 @@ def plot_all_DDGs(
         whether to account for uncertainty in x when bootstrapping
     bootstrap_y_uncertainty : bool, default False
         whether to account for uncertainty in y when bootstrapping
+    statistic_type : str, default 'mle'
+        the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
 
     Returns
     -------
@@ -523,6 +540,7 @@ def plot_all_DDGs(
             target_name=target_name,
             bootstrap_x_uncertainty=bootstrap_x_uncertainty,
             bootstrap_y_uncertainty=bootstrap_y_uncertainty,
+            statistic_type=statistic_type,
             **kwargs,
         )
 
@@ -539,5 +557,6 @@ def plot_all_DDGs(
             shift=shift,
             bootstrap_x_uncertainty=bootstrap_x_uncertainty,
             bootstrap_y_uncertainty=bootstrap_y_uncertainty,
+            statistic_type=statistic_type,
             **kwargs,
         )

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -96,6 +96,7 @@ def _master_plot(
         whether to account for uncertainty in y when bootstrapping
     statistic_type : str, default 'mle'
         the type of statistic to use, either 'mle' or 'mean' (of the bootstrapped data)
+
     Returns
     -------
 

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -176,7 +176,7 @@ def _master_plot(
     # stats and title
     statistics_string = ""
     if statistic_type not in ['mle', 'mean']:
-        raise Exception(f"Unknown statistic type {statistic_type}")
+        raise ValueError(f"Unknown statistic type {statistic_type}")
     for statistic in statistics:
         s = stats.bootstrap_statistic(x,
                                       y,

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -374,7 +374,7 @@ def plot_DGs(
     centralizing: bool = True,
     shift: float = 0.0,
     bootstrap_x_uncertainty: bool = False,
-    bootstrap_y_uncertainty: bool=False,
+    bootstrap_y_uncertainty: bool = False,
     statistic_type: str = "mle",
     **kwargs,
 ):

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -32,8 +32,8 @@ def _master_plot(
     axis_padding: float = 0.5,
     xy_lim: list = [],
     font_sizes: dict = {"title": 12, "labels": 9, "other": 12},
-    bootstrap_experimental_uncertainty: bool = False,
-    bootstrap_predicted_uncertainty: bool=False,
+    bootstrap_x_uncertainty: bool = False,
+    bootstrap_y_uncertainty: bool = False,
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -89,10 +89,10 @@ def _master_plot(
         contains the minimium and maximum values to use for the x and y axes. if specified, axis_padding is ignored
     font_sizes : dict, default {"title": 12, "labels": 9, "other": 12}
         font sizes to use for the title ("title"), the data labels ("labels"), and the rest of the plot ("other")
-    bootstrap_experimental_uncertainty : bool, default False
-        whether to account for experimental uncertainty when bootstrapping
-    bootstrap_predicted_uncertainty : bool, default False
-        whether to account for predicted uncertainty when bootstrapping
+    bootstrap_x_uncertainty : bool, default False
+        whether to account for uncertainty in x when bootstrapping
+    bootstrap_y_uncertainty : bool, default False
+        whether to account for uncertainty in y when bootstrapping
     Returns
     -------
 
@@ -177,8 +177,8 @@ def _master_plot(
                                       xerr,
                                       yerr,
                                       statistic=statistic,
-                                      bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-                                      bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty)
+                                      bootstrap_true_uncertainty=bootstrap_x_uncertainty,
+                                      bootstrap_pred_uncertainty=bootstrap_y_uncertainty)
         string = f"{statistic}:   {s['mean']:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
         statistics_string += string
 
@@ -209,8 +209,8 @@ def plot_DDGs(
     symmetrise: bool = False,
     plotly: bool = False,
     data_label_type: str = None,
-    bootstrap_experimental_uncertainty: bool = False,
-    bootstrap_predicted_uncertainty: bool = False,
+    bootstrap_x_uncertainty: bool = False,
+    bootstrap_y_uncertainty: bool=False,
     **kwargs,
 ):
     """Function to plot relative free energies
@@ -248,10 +248,10 @@ def plot_DDGs(
             the negative of the transformation
         currently unsupported for plotly-generated plots
         TODO: implement data labeling for the case where plotly=True
-    bootstrap_experimental_uncertainty : bool, default False
-        whether to account for experimental uncertainty when bootstrapping
-    bootstrap_predicted_uncertainty : bool, default False
-        whether to account for predicted uncertainty when bootstrapping
+    bootstrap_x_uncertainty : bool, default False
+        whether to account for uncertainty in x when bootstrapping
+    bootstrap_y_uncertainty : bool, default False
+        whether to account for uncertainty in y when bootstrapping
 
     Returns
     -------
@@ -333,8 +333,8 @@ def plot_DDGs(
             title=title,
             method_name=method_name,
             target_name=target_name,
-            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
+            bootstrap_x_uncertainty=bootstrap_x_uncertainty,
+            bootstrap_y_uncertainty=bootstrap_y_uncertainty,
             **kwargs,
         )
     else:
@@ -348,8 +348,8 @@ def plot_DDGs(
             method_name=method_name,
             target_name=target_name,
             data_labels=data_labels,
-            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
+            bootstrap_x_uncertainty=bootstrap_x_uncertainty,
+            bootstrap_y_uncertainty=bootstrap_y_uncertainty,
             **kwargs,
         )
 
@@ -363,8 +363,8 @@ def plot_DGs(
     plotly: bool = False,
     centralizing: bool = True,
     shift: float = 0.0,
-    bootstrap_experimental_uncertainty: bool = False,
-    bootstrap_predicted_uncertainty: bool = False,
+    bootstrap_x_uncertainty: bool = False,
+    bootstrap_y_uncertainty: bool=False,
     **kwargs,
 ):
     """Function to plot absolute free energies.
@@ -381,10 +381,10 @@ def plot_DGs(
         Title for the plot
     filename : str, default = None
         filename for plot
-    bootstrap_experimental_uncertainty : bool, default False
-        whether to account for experimental uncertainty when bootstrapping
-    bootstrap_predicted_uncertainty : bool, default False
-        whether to account for predicted uncertainty when bootstrapping
+    bootstrap_x_uncertainty : bool, default False
+        whether to account for uncertainty in x when bootstrapping
+    bootstrap_y_uncertainty : bool, default False
+        whether to account for uncertainty in y when bootstrapping
 
     Returns
     -------
@@ -416,8 +416,8 @@ def plot_DGs(
             method_name=method_name,
             target_name=target_name,
             filename=filename,
-            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
+            bootstrap_x_uncertainty=bootstrap_x_uncertainty,
+            bootstrap_y_uncertainty=bootstrap_y_uncertainty,
             **kwargs,
         )
     else:
@@ -433,8 +433,8 @@ def plot_DGs(
             method_name=method_name,
             target_name=target_name,
             filename=filename,
-            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
+            bootstrap_x_uncertainty=bootstrap_x_uncertainty,
+            bootstrap_y_uncertainty=bootstrap_y_uncertainty,
             **kwargs,
         )
 
@@ -447,8 +447,8 @@ def plot_all_DDGs(
     filename: Optional[str] = None,
     plotly: bool = False,
     shift: float = 0.0,
-    bootstrap_experimental_uncertainty: bool = False,
-    bootstrap_predicted_uncertainty: bool = False,
+    bootstrap_x_uncertainty: bool = False,
+    bootstrap_y_uncertainty: bool=False,
     **kwargs,
 ):
     """Plots relative free energies between all ligands, which is calculated from
@@ -470,10 +470,10 @@ def plot_all_DDGs(
         whether to use plotly for the plotting
     shift : float, default = 0.
         shift both the x and y axis by a constant
-    bootstrap_experimental_uncertainty : bool, default False
-        whether to account for experimental uncertainty when bootstrapping
-    bootstrap_predicted_uncertainty : bool, default False
-        whether to account for predicted uncertainty when bootstrapping
+    bootstrap_x_uncertainty : bool, default False
+        whether to account for uncertainty in x when bootstrapping
+    bootstrap_y_uncertainty : bool, default False
+        whether to account for uncertainty in y when bootstrapping
 
     Returns
     -------
@@ -520,8 +520,8 @@ def plot_all_DDGs(
             plot_type="ΔΔG",
             filename=filename,
             target_name=target_name,
-            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
+            bootstrap_x_uncertainty=bootstrap_x_uncertainty,
+            bootstrap_y_uncertainty=bootstrap_y_uncertainty,
             **kwargs,
         )
 
@@ -536,7 +536,7 @@ def plot_all_DDGs(
             filename=filename,
             target_name=target_name,
             shift=shift,
-            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
-            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
+            bootstrap_x_uncertainty=bootstrap_x_uncertainty,
+            bootstrap_y_uncertainty=bootstrap_y_uncertainty,
             **kwargs,
         )

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -32,6 +32,8 @@ def _master_plot(
     axis_padding: float = 0.5,
     xy_lim: list = [],
     font_sizes: dict = {"title": 12, "labels": 9, "other": 12},
+    bootstrap_experimental_uncertainty: bool = False,
+    bootstrap_predicted_uncertainty: bool=False,
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -87,7 +89,10 @@ def _master_plot(
         contains the minimium and maximum values to use for the x and y axes. if specified, axis_padding is ignored
     font_sizes : dict, default {"title": 12, "labels": 9, "other": 12}
         font sizes to use for the title ("title"), the data labels ("labels"), and the rest of the plot ("other")
-
+    bootstrap_experimental_uncertainty : bool, default False
+        whether to account for experimental uncertainty when bootstrapping
+    bootstrap_predicted_uncertainty : bool, default False
+        whether to account for predicted uncertainty when bootstrapping
     Returns
     -------
 
@@ -167,8 +172,14 @@ def _master_plot(
     # stats and title
     statistics_string = ""
     for statistic in statistics:
-        s = stats.bootstrap_statistic(x, y, xerr, yerr, statistic=statistic)
-        string = f"{statistic}:   {s['mle']:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
+        s = stats.bootstrap_statistic(x,
+                                      y,
+                                      xerr,
+                                      yerr,
+                                      statistic=statistic,
+                                      bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+                                      bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty)
+        string = f"{statistic}:   {s['mean']:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
         statistics_string += string
 
     long_title = f"{title} \n {target_name} (N = {nsamples}) \n {statistics_string}"
@@ -198,6 +209,8 @@ def plot_DDGs(
     symmetrise: bool = False,
     plotly: bool = False,
     data_label_type: str = None,
+    bootstrap_experimental_uncertainty: bool = False,
+    bootstrap_predicted_uncertainty: bool = False,
     **kwargs,
 ):
     """Function to plot relative free energies
@@ -235,6 +248,10 @@ def plot_DDGs(
             the negative of the transformation
         currently unsupported for plotly-generated plots
         TODO: implement data labeling for the case where plotly=True
+    bootstrap_experimental_uncertainty : bool, default False
+        whether to account for experimental uncertainty when bootstrapping
+    bootstrap_predicted_uncertainty : bool, default False
+        whether to account for predicted uncertainty when bootstrapping
 
     Returns
     -------
@@ -316,6 +333,8 @@ def plot_DDGs(
             title=title,
             method_name=method_name,
             target_name=target_name,
+            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
             **kwargs,
         )
     else:
@@ -329,6 +348,8 @@ def plot_DDGs(
             method_name=method_name,
             target_name=target_name,
             data_labels=data_labels,
+            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
             **kwargs,
         )
 
@@ -342,6 +363,8 @@ def plot_DGs(
     plotly: bool = False,
     centralizing: bool = True,
     shift: float = 0.0,
+    bootstrap_experimental_uncertainty: bool = False,
+    bootstrap_predicted_uncertainty: bool = False,
     **kwargs,
 ):
     """Function to plot absolute free energies.
@@ -358,6 +381,10 @@ def plot_DGs(
         Title for the plot
     filename : str, default = None
         filename for plot
+    bootstrap_experimental_uncertainty : bool, default False
+        whether to account for experimental uncertainty when bootstrapping
+    bootstrap_predicted_uncertainty : bool, default False
+        whether to account for predicted uncertainty when bootstrapping
 
     Returns
     -------
@@ -389,6 +416,8 @@ def plot_DGs(
             method_name=method_name,
             target_name=target_name,
             filename=filename,
+            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
             **kwargs,
         )
     else:
@@ -404,6 +433,8 @@ def plot_DGs(
             method_name=method_name,
             target_name=target_name,
             filename=filename,
+            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
             **kwargs,
         )
 
@@ -416,6 +447,8 @@ def plot_all_DDGs(
     filename: Optional[str] = None,
     plotly: bool = False,
     shift: float = 0.0,
+    bootstrap_experimental_uncertainty: bool = False,
+    bootstrap_predicted_uncertainty: bool = False,
     **kwargs,
 ):
     """Plots relative free energies between all ligands, which is calculated from
@@ -437,6 +470,10 @@ def plot_all_DDGs(
         whether to use plotly for the plotting
     shift : float, default = 0.
         shift both the x and y axis by a constant
+    bootstrap_experimental_uncertainty : bool, default False
+        whether to account for experimental uncertainty when bootstrapping
+    bootstrap_predicted_uncertainty : bool, default False
+        whether to account for predicted uncertainty when bootstrapping
 
     Returns
     -------
@@ -483,6 +520,8 @@ def plot_all_DDGs(
             plot_type="ΔΔG",
             filename=filename,
             target_name=target_name,
+            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
             **kwargs,
         )
 
@@ -497,5 +536,7 @@ def plot_all_DDGs(
             filename=filename,
             target_name=target_name,
             shift=shift,
+            bootstrap_experimental_uncertainty=bootstrap_experimental_uncertainty,
+            bootstrap_predicted_uncertainty=bootstrap_predicted_uncertainty,
             **kwargs,
         )

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -215,7 +215,7 @@ def plot_DDGs(
     plotly: bool = False,
     data_label_type: str = None,
     bootstrap_x_uncertainty: bool = False,
-    bootstrap_y_uncertainty: bool=False,
+    bootstrap_y_uncertainty: bool = False,
     statistic_type: str = "mle",
     **kwargs,
 ):
@@ -463,7 +463,7 @@ def plot_all_DDGs(
     plotly: bool = False,
     shift: float = 0.0,
     bootstrap_x_uncertainty: bool = False,
-    bootstrap_y_uncertainty: bool=False,
+    bootstrap_y_uncertainty: bool = False,
     statistic_type: str = "mle",
     **kwargs,
 ):

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -179,7 +179,8 @@ def _master_plot(
                                       statistic=statistic,
                                       bootstrap_true_uncertainty=bootstrap_x_uncertainty,
                                       bootstrap_pred_uncertainty=bootstrap_y_uncertainty)
-        string = f"{statistic}:   {s['mean']:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
+        statistic_type = 'mean' if bootstrap_x_uncertainty or bootstrap_y_uncertainty else 'mle'
+        string = f"{statistic}:   {s[statistic_type]:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
         statistics_string += string
 
     long_title = f"{title} \n {target_name} (N = {nsamples}) \n {statistics_string}"

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -177,8 +177,8 @@ def _master_plot(
                                       xerr,
                                       yerr,
                                       statistic=statistic,
-                                      bootstrap_true_uncertainty=bootstrap_x_uncertainty,
-                                      bootstrap_pred_uncertainty=bootstrap_y_uncertainty)
+                                      include_true_uncertainty=bootstrap_x_uncertainty,
+                                      include_pred_uncertainty=bootstrap_y_uncertainty)
         statistic_type = 'mean' if bootstrap_x_uncertainty or bootstrap_y_uncertainty else 'mle'
         string = f"{statistic}:   {s[statistic_type]:.2f} [95%: {s['low']:.2f}, {s['high']:.2f}] " + "\n"
         statistics_string += string

--- a/cinnabar/stats.py
+++ b/cinnabar/stats.py
@@ -14,6 +14,8 @@ def bootstrap_statistic(
     statistic: str = "RMSE",
     nbootstrap: int = 1000,
     plot_type: str = "dG",
+    bootstrap_experimental_uncertainty: bool = False,
+    bootstrap_predicted_uncertainty: bool = False,
 ) -> dict:
 
     """Compute mean and confidence intervals of specified statistic.
@@ -36,6 +38,10 @@ def bootstrap_statistic(
         Number of bootstrap samples
     plot_type : str, optional, default='dG'
         'dG' or 'ddG'
+    bootstrap_experimental_uncertainty : bool, default False
+        whether to account for experimental uncertainty when bootstrapping
+    bootstrap_predicted_uncertainty : bool, default False
+        whether to account for predicted uncertainty when bootstrapping
 
     Returns
     -------
@@ -114,8 +120,10 @@ def bootstrap_statistic(
         for i, j in enumerate(
             np.random.choice(np.arange(sample_size), size=[sample_size], replace=True)
         ):
-            y_true_sample[i] = np.random.normal(loc=y_true[j], scale=np.fabs(dy_true[j]), size=1)
-            y_pred_sample[i] = np.random.normal(loc=y_pred[j], scale=np.fabs(dy_pred[j]), size=1)
+            stddev_true = np.fabs(dy_true[j]) if bootstrap_experimental_uncertainty else 0
+            stddev_pred = np.fabs(dy_pred[j]) if bootstrap_predicted_uncertainty else 0
+            y_true_sample[i] = np.random.normal(loc=y_true[j], scale=stddev_true, size=1)
+            y_pred_sample[i] = np.random.normal(loc=y_pred[j], scale=stddev_pred, size=1)
         s_n[replicate] = compute_statistic(y_true_sample, y_pred_sample, statistic)
 
     rmse_stats = dict()

--- a/cinnabar/stats.py
+++ b/cinnabar/stats.py
@@ -14,8 +14,8 @@ def bootstrap_statistic(
     statistic: str = "RMSE",
     nbootstrap: int = 1000,
     plot_type: str = "dG",
-    bootstrap_experimental_uncertainty: bool = False,
-    bootstrap_predicted_uncertainty: bool = False,
+    bootstrap_true_uncertainty: bool = False,
+    bootstrap_pred_uncertainty: bool = False,
 ) -> dict:
 
     """Compute mean and confidence intervals of specified statistic.
@@ -38,10 +38,10 @@ def bootstrap_statistic(
         Number of bootstrap samples
     plot_type : str, optional, default='dG'
         'dG' or 'ddG'
-    bootstrap_experimental_uncertainty : bool, default False
-        whether to account for experimental uncertainty when bootstrapping
-    bootstrap_predicted_uncertainty : bool, default False
-        whether to account for predicted uncertainty when bootstrapping
+    bootstrap_true_uncertainty : bool, default False
+        whether to account for the uncertainty in the y_true when bootstrapping
+    bootstrap_pred_uncertainty : bool, default False
+        whether to account for the uncertainty in y_pred when bootstrapping
 
     Returns
     -------
@@ -120,8 +120,8 @@ def bootstrap_statistic(
         for i, j in enumerate(
             np.random.choice(np.arange(sample_size), size=[sample_size], replace=True)
         ):
-            stddev_true = np.fabs(dy_true[j]) if bootstrap_experimental_uncertainty else 0
-            stddev_pred = np.fabs(dy_pred[j]) if bootstrap_predicted_uncertainty else 0
+            stddev_true = np.fabs(dy_true[j]) if bootstrap_true_uncertainty else 0
+            stddev_pred = np.fabs(dy_pred[j]) if bootstrap_pred_uncertainty else 0
             y_true_sample[i] = np.random.normal(loc=y_true[j], scale=stddev_true, size=1)
             y_pred_sample[i] = np.random.normal(loc=y_pred[j], scale=stddev_pred, size=1)
         s_n[replicate] = compute_statistic(y_true_sample, y_pred_sample, statistic)

--- a/cinnabar/stats.py
+++ b/cinnabar/stats.py
@@ -14,8 +14,8 @@ def bootstrap_statistic(
     statistic: str = "RMSE",
     nbootstrap: int = 1000,
     plot_type: str = "dG",
-    bootstrap_true_uncertainty: bool = False,
-    bootstrap_pred_uncertainty: bool = False,
+    include_true_uncertainty: bool = False,
+    include_pred_uncertainty: bool = False,
 ) -> dict:
 
     """Compute mean and confidence intervals of specified statistic.
@@ -38,9 +38,9 @@ def bootstrap_statistic(
         Number of bootstrap samples
     plot_type : str, optional, default='dG'
         'dG' or 'ddG'
-    bootstrap_true_uncertainty : bool, default False
+    include_true_uncertainty : bool, default False
         whether to account for the uncertainty in y_true when bootstrapping
-    bootstrap_pred_uncertainty : bool, default False
+    include_pred_uncertainty : bool, default False
         whether to account for the uncertainty in y_pred when bootstrapping
 
     Returns
@@ -120,8 +120,8 @@ def bootstrap_statistic(
         for i, j in enumerate(
             np.random.choice(np.arange(sample_size), size=[sample_size], replace=True)
         ):
-            stddev_true = np.fabs(dy_true[j]) if bootstrap_true_uncertainty else 0
-            stddev_pred = np.fabs(dy_pred[j]) if bootstrap_pred_uncertainty else 0
+            stddev_true = np.fabs(dy_true[j]) if include_true_uncertainty else 0
+            stddev_pred = np.fabs(dy_pred[j]) if include_pred_uncertainty else 0
             y_true_sample[i] = np.random.normal(loc=y_true[j], scale=stddev_true, size=1)
             y_pred_sample[i] = np.random.normal(loc=y_pred[j], scale=stddev_pred, size=1)
         s_n[replicate] = compute_statistic(y_true_sample, y_pred_sample, statistic)

--- a/cinnabar/stats.py
+++ b/cinnabar/stats.py
@@ -39,7 +39,7 @@ def bootstrap_statistic(
     plot_type : str, optional, default='dG'
         'dG' or 'ddG'
     bootstrap_true_uncertainty : bool, default False
-        whether to account for the uncertainty in the y_true when bootstrapping
+        whether to account for the uncertainty in y_true when bootstrapping
     bootstrap_pred_uncertainty : bool, default False
         whether to account for the uncertainty in y_pred when bootstrapping
 

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -162,8 +162,8 @@ def test_confidence_intervals(fe_map):
     yerr = np.asarray([n[1]["calc_dDG"] for n in nodes(data=True)])
 
     # RMSE (default mode)
-    bss_default = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
-    assert bss_default['low'] < bss_default['mle'] < bss_default['high'], \
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
+    assert bss['low'] < bss['mle'] < bss['high'], \
         "The RMSE must lie within the bootstrapped 95% CI"
 
     # MUE (default mode)

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -2,8 +2,10 @@ import itertools
 
 import networkx as nx
 import numpy as np
+import pytest
 from cinnabar import stats
 from cinnabar.stats import bootstrap_statistic
+
 
 def test_mle_easy():
     """

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -163,8 +163,10 @@ def test_confidence_intervals(fe_map):
 
     # RMSE
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
-    assert bss['low'] < bss['mean'] < bss['high'], "The RMSE must lie withint the bootstrapped 95% CI"
+    assert bss['low'] < bss['mean'] < bss['high'], \
+        "The RMSE must lie within the bootstrapped 95% CI"
 
     # MUE
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="MUE")
-    assert bss['low'] < bss['mean'] < bss['high'], "The MUE must lie withint the bootstrapped 95% CI"
+    assert bss['low'] < bss['mean'] < bss['high'], \
+        "The MUE must lie within the bootstrapped 95% CI"

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -149,9 +149,9 @@ def test_correlation_positive(fe_map):
 
 def test_confidence_intervals(fe_map):
     """
-    Test that the confidence intervals for RMSE and MUE contain the
-    corresponding statistics. Uses the example data in
-    `cinnabar/data/example.csv`
+    Test that the bootstrapped confidence intervals
+    for RMSE and MUE contain the corresponding statistics.
+    Uses the example data in `cinnabar/data/example.csv`
     """
 
     nodes = fe_map.graph.nodes
@@ -161,12 +161,31 @@ def test_confidence_intervals(fe_map):
     xerr = np.asarray([n[1]["exp_dDG"] for n in nodes(data=True)])
     yerr = np.asarray([n[1]["calc_dDG"] for n in nodes(data=True)])
 
-    # RMSE
-    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
+    # RMSE (default mode)
+    bss_default = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
+    assert bss_default['low'] < bss_default['mle'] < bss_default['high'], \
+        "The RMSE must lie within the bootstrapped 95% CI"
+
+    # MUE (default mode)
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="MUE")
+    assert bss['low'] < bss['mle'] < bss['high'], \
+        "The MUE must lie within the bootstrapped 95% CI"
+
+    # RMSE (including xerr in bootstrapping)
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
+                              include_true_uncertainty=True)
     assert bss['low'] < bss['mean'] < bss['high'], \
         "The RMSE must lie within the bootstrapped 95% CI"
 
-    # MUE
-    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="MUE")
+    # RMSE (including yerr in bootstrapping)
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
+                              include_pred_uncertainty=True)
     assert bss['low'] < bss['mean'] < bss['high'], \
-        "The MUE must lie within the bootstrapped 95% CI"
+        "The RMSE must lie within the bootstrapped 95% CI"
+
+    # RMSE (including both xerr and yerr in bootstrapping)
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
+                              include_true_uncertainty=True,
+                              include_pred_uncertainty=True)
+    assert bss['low'] < bss['mean'] < bss['high'], \
+        "The RMSE must lie within the bootstrapped 95% CI"

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -5,8 +5,6 @@ import numpy as np
 from cinnabar import stats
 from cinnabar.stats import bootstrap_statistic
 
-import pytest
-
 def test_mle_easy():
     """
     Test that the MLE for a graph with an absolute

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -5,6 +5,7 @@ import numpy as np
 from cinnabar import stats
 from cinnabar.stats import bootstrap_statistic
 
+import pytest
 
 def test_mle_easy():
     """
@@ -161,31 +162,28 @@ def test_confidence_intervals(fe_map):
     xerr = np.asarray([n[1]["exp_dDG"] for n in nodes(data=True)])
     yerr = np.asarray([n[1]["calc_dDG"] for n in nodes(data=True)])
 
+    error_message =  "The RMSE must lie within the bootstrapped 95% CI"
+
     # RMSE (default mode)
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
-    assert bss['low'] < bss['mle'] < bss['high'], \
-        "The RMSE must lie within the bootstrapped 95% CI"
+    assert bss['low'] < bss['mle'] < bss['high'], error_message
 
     # MUE (default mode)
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="MUE")
-    assert bss['low'] < bss['mle'] < bss['high'], \
-        "The MUE must lie within the bootstrapped 95% CI"
+    assert bss['low'] < bss['mle'] < bss['high'], error_message
 
     # RMSE (including xerr in bootstrapping)
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
                               include_true_uncertainty=True)
-    assert bss['low'] < bss['mean'] < bss['high'], \
-        "The RMSE must lie within the bootstrapped 95% CI"
+    assert bss['low'] < bss['mean'] < bss['high'], error_message
 
     # RMSE (including yerr in bootstrapping)
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
                               include_pred_uncertainty=True)
-    assert bss['low'] < bss['mean'] < bss['high'], \
-        "The RMSE must lie within the bootstrapped 95% CI"
+    assert bss['low'] < bss['mean'] < bss['high'], error_message
 
     # RMSE (including both xerr and yerr in bootstrapping)
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
                               include_true_uncertainty=True,
                               include_pred_uncertainty=True)
-    assert bss['low'] < bss['mean'] < bss['high'], \
-        "The RMSE must lie within the bootstrapped 95% CI"
+    assert bss['low'] < bss['mean'] < bss['high'], error_message

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -185,3 +185,23 @@ def test_confidence_intervals(fe_map):
                               include_true_uncertainty=True,
                               include_pred_uncertainty=True)
     assert bss['low'] < bss['mean'] < bss['high'], error_message
+
+
+def test_confidence_interval_edge_case():
+    """
+    Test that the bootstrapped confidence interval
+    for RMSE contains the sample estimate.
+    Uses the data from https://github.com/OpenFreeEnergy/cinnabar/issues/73
+    """
+
+    # Data from Cinnabar issue #73
+    x_data = [-0.101, 0.351, 0.117, 0.623, 5.172, 5.209, -1.727, -1.387, -1.534, 1.082]
+    y_data = [-0.174, 0.42, 0.262, 0.626, 5.064, 4.783, -1.58, -1.712, -1.699, 0.822]
+    xerr = [0.443, 0.652, 0.57, 0.245, 1.112, 1.049, 1.23, 1.435, 1.521, 0.505]
+    yerr = [0.442, 0.714, 0.619, 0.224, 1.401, 1.107, 1.178, 1.252, 1.265, 0.472]
+
+    # RMSE (default mode)
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
+                              include_true_uncertainty=True,
+                              include_pred_uncertainty=True)
+    assert (bss['low'] > bss['mle']) or (bss['mle'] > bss['high']), error_message

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -145,3 +145,24 @@ def test_correlation_positive(fe_map):
         assert (
             0.5 < bss["mle"] < 0.9
         ), f"Correlation must be positive for this data. {stat} is {bss['mle']}"
+
+def test_confidence_intervals(fe_map):
+    """
+    Test that the confidence intervals for RMSE and MUE contain the corresponding statistics.
+    Uses the example data in `cinnabar/data/example.csv`
+    """
+
+    nodes = fe_map.graph.nodes
+
+    x_data = np.asarray([n[1]["exp_DG"] for n in nodes(data=True)])
+    y_data = np.asarray([n[1]["calc_DG"] for n in nodes(data=True)])
+    xerr = np.asarray([n[1]["exp_dDG"] for n in nodes(data=True)])
+    yerr = np.asarray([n[1]["calc_dDG"] for n in nodes(data=True)])
+
+    # RMSE
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE")
+    assert bss['low'] < bss['mean'] < bss['high'], "The RMSE must lie withint the bootstrapped 95% CI"
+
+    # MUE
+    bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="MUE")
+    assert bss['low'] < bss['mean'] < bss['high'], "The MUE must lie withint the bootstrapped 95% CI"


### PR DESCRIPTION
## Description
Fixes https://github.com/OpenFreeEnergy/cinnabar/issues/73 -- where in some cases, the RMSE and MUE does not lie within the 95% CI

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Change the default bootstrapping mode to only account for finite sample size effects (tells us how well we fit the data)
  - [x] Support the old bootstrapping mode (which also accounts for simulating what would happen if we ran the experiment and/or calculation many times) by allowing the user to separately control whether experimental and predicted uncertainty should be included when bootstrapping

<strike>  - [x] For both modes, instead of reporting the MLE of RMSE and MUE, report the mean of the bootstrapped data</strike>
  - [x] For the default mode, continue to report the sample estimate of the RMSE and MUE. For the old mode, report the mean of the bootstrapped data

## Status
- [x] Ready to go