### PR TITLE
Fix test_confidence_interval_edge_case

### DIFF
--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -214,4 +214,4 @@ def test_confidence_interval_edge_case():
                               include_true_uncertainty=False,
                               include_pred_uncertainty=False)
     error_message = "The stat must lie within the bootstrapped 95% CI"
-    assert (bss['low'] < bss['mle']) or (bss['mle'] < bss['high']), error_message
+    assert (bss['low'] < bss['mle']) and (bss['mle'] < bss['high']), error_message

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -211,6 +211,7 @@ def test_confidence_interval_edge_case():
 
     # RMSE (default mode)
     bss = bootstrap_statistic(x_data, y_data, xerr, yerr, statistic="RMSE",
-                              include_true_uncertainty=True,
-                              include_pred_uncertainty=True)
-    assert (bss['low'] > bss['mle']) or (bss['mle'] > bss['high']), error_message
+                              include_true_uncertainty=False,
+                              include_pred_uncertainty=False)
+    error_message = "The stat must lie within the bootstrapped 95% CI"
+    assert (bss['low'] < bss['mle']) or (bss['mle'] < bss['high']), error_message


### PR DESCRIPTION
## Description
Fixes `test_confidence_interval_edge_case` which was introduced in https://github.com/OpenFreeEnergy/cinnabar/pull/74

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Defines `error_message` (previously undefined)
  - [x] Fixed the assert statement, which was previously checking that when using the old behavior (i.e. use the sample statistic and include the true and predicted uncertainty when bootstrapping), the sample RMSE statistic lies outside of the 95% confidence interval. We instead want to test that the new default behavior works properly for the old data.

## Status
- [x] Ready to go