### PR TITLE
Allow control of marker size (and other aspects of plt.scatter)

### DIFF
--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -29,11 +29,10 @@ def _master_plot(
     figsize: float = 3.25,
     dpi: Union[float, str] = "figure",
     data_labels: list = [],
-    data_label_filter: Optional[float] = None,
     axis_padding: float = 0.5,
     xy_lim: list = [],
     font_sizes: dict = {"title": 12, "labels": 9, "other": 12},
-    marker_size: float = 10,
+    marker_size : float = 10,
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -83,8 +82,6 @@ def _master_plot(
         https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html)
     data_labels : list of str, default []
         list of labels for each data point
-    data_label_filter : float, default None
-        only show labels for data points where the abs(x - y) > data_label_filter
     axis_padding : float, default = 0.5
         padding to add to maximum axis value and subtract from the minimum axis value
     xy_lim : list, default []
@@ -165,13 +162,8 @@ def _master_plot(
     plt.scatter(x, y, color=color, s=marker_size, marker="o", zorder=2)
 
     # Label points
-    # If data_label_filter is specified, only label data points that are outliers
-    # (i.e. where the difference in x and y is larger than data_label_filter)
     texts = []
     for i, label in enumerate(data_labels):
-        if data_label_filter is not None:
-            if abs(x[i] - y[i]) <= data_label_filter:
-                continue
         texts.append(plt.text(x[i] + 0.03, y[i] + 0.03, label, fontsize=font_sizes["labels"]))
     adjust_text(texts)
 

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -98,7 +98,7 @@ def _master_plot(
     statistic_type : str, default 'mle'
         the type of statistic to use, either 'mle' (i.e. sample statistic)
         or 'mean' (i.e. bootstrapped mean statistic)
-    scatter_kwargs : dict, default {}
+    scatter_kwargs : dict, default {"s": 10, "marker": "o"}
         arguments to control plt.scatter()
 
     Returns

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -32,6 +32,7 @@ def _master_plot(
     axis_padding: float = 0.5,
     xy_lim: list = [],
     font_sizes: dict = {"title": 12, "labels": 9, "other": 12},
+    marker_size : float = 10,
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -87,6 +88,8 @@ def _master_plot(
         contains the minimium and maximum values to use for the x and y axes. if specified, axis_padding is ignored
     font_sizes : dict, default {"title": 12, "labels": 9, "other": 12}
         font sizes to use for the title ("title"), the data labels ("labels"), and the rest of the plot ("other")
+    marker_size : float, default 10
+        size of the markers representing each data point in the scatter plot
 
     Returns
     -------
@@ -156,7 +159,7 @@ def _master_plot(
         elinewidth=2.0,
         zorder=1,
     )
-    plt.scatter(x, y, color=color, s=10, marker="o", zorder=2)
+    plt.scatter(x, y, color=color, s=marker_size, marker="o", zorder=2)
 
     # Label points
     texts = []

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -35,7 +35,7 @@ def _master_plot(
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool = False,
     statistic_type: str = "mle",
-    scatter_kwargs: dict = {},
+    scatter_kwargs: dict = {"s": 10, "marker": "o"},
 ):
     """Handles the aesthetics of the plots in one place.
 

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -35,7 +35,7 @@ def _master_plot(
     bootstrap_x_uncertainty: bool = False,
     bootstrap_y_uncertainty: bool = False,
     statistic_type: str = "mle",
-    marker_size: float = 10,
+    scatter_kwargs: dict = {},
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -98,8 +98,8 @@ def _master_plot(
     statistic_type : str, default 'mle'
         the type of statistic to use, either 'mle' (i.e. sample statistic)
         or 'mean' (i.e. bootstrapped mean statistic)
-    marker_size : float, default 10
-        size of the markers representing each data point in the scatter plot
+    scatter_kwargs : dict, default {}
+        arguments to control plt.scatter()
 
     Returns
     -------
@@ -169,7 +169,7 @@ def _master_plot(
         elinewidth=2.0,
         zorder=1,
     )
-    plt.scatter(x, y, color=color, s=marker_size, marker="o", zorder=2)
+    plt.scatter(x, y, color=color, zorder=2, **scatter_kwargs)
 
     # Label points
     texts = []

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -29,10 +29,11 @@ def _master_plot(
     figsize: float = 3.25,
     dpi: Union[float, str] = "figure",
     data_labels: list = [],
+    data_label_filter: Optional[float] = None,
     axis_padding: float = 0.5,
     xy_lim: list = [],
     font_sizes: dict = {"title": 12, "labels": 9, "other": 12},
-    marker_size : float = 10,
+    marker_size: float = 10,
 ):
     """Handles the aesthetics of the plots in one place.
 
@@ -82,6 +83,8 @@ def _master_plot(
         https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html)
     data_labels : list of str, default []
         list of labels for each data point
+    data_label_filter : float, default None
+        only show labels for data points where the abs(x - y) > data_label_filter
     axis_padding : float, default = 0.5
         padding to add to maximum axis value and subtract from the minimum axis value
     xy_lim : list, default []
@@ -162,8 +165,13 @@ def _master_plot(
     plt.scatter(x, y, color=color, s=marker_size, marker="o", zorder=2)
 
     # Label points
+    # If data_label_filter is specified, only label data points that are outliers
+    # (i.e. where the difference in x and y is larger than data_label_filter)
     texts = []
     for i, label in enumerate(data_labels):
+        if data_label_filter is not None:
+            if abs(x[i] - y[i]) <= data_label_filter:
+                continue
         texts.append(plt.text(x[i] + 0.03, y[i] + 0.03, label, fontsize=font_sizes["labels"]))
     adjust_text(texts)
 


### PR DESCRIPTION
## Description
Allow user to control the size of the markers (and other arguments) in plt.scatter()

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Introduces `scatter_kwargs` argument to `plotting._master_plot`

## Status
- [x] Ready to go