### PR TITLE
Adds FEMap To/from networkx

### DIFF
--- a/cinnabar/measurements.py
+++ b/cinnabar/measurements.py
@@ -50,6 +50,9 @@ class ReferenceState:
 
 class Measurement(DefaultModel):
     """The free energy difference of moving from A to B"""
+    class Config:
+        frozen = True
+
     labelA: Hashable
     labelB: Hashable
     DG: FloatQuantity['kilocalorie_per_mole']

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -26,7 +26,21 @@ def example_map(example_csv):
 def test_from_csv(example_map):
     assert example_map.n_ligands == 36
     assert example_map.n_edges == 58
-    assert len(example_map.graph.edges) == (58 + 36) * 2
+    assert len(example_map._graph.edges) == (58 + 36) * 2
+
+
+def test_eq(example_csv):
+    m1 = cinnabar.FEMap.from_csv(example_csv)
+    m2 = cinnabar.FEMap.from_csv(example_csv)
+    m3 = cinnabar.FEMap.from_csv(example_csv)
+    m3.add_experimental_measurement(
+        label='this',
+        value=4.2 * unit.kilocalorie_per_mole,
+        uncertainty=0.1 * unit.kilocalorie_per_mole,
+    )
+
+    assert m1 == m2
+    assert m1 != m3
 
 
 def test_degree(example_map):
@@ -77,7 +91,7 @@ def test_femap_add_experimental(ki):
     )
 
     assert set(m.ligands) == {'ligA'}
-    d = m.graph.get_edge_data(cinnabar.ReferenceState(), 'ligA')
+    d = m._graph.get_edge_data(cinnabar.ReferenceState(), 'ligA')
     assert d.keys() == {0}
     d = d[0]
     assert d['computational'] is False
@@ -118,7 +132,7 @@ def test_add_ABFE(default_T):
                                    source='ebay', temperature=T)
 
     assert set(m.ligands) == {'foo'}
-    d = m.graph.get_edge_data(cinnabar.ReferenceState(), 'foo')
+    d = m._graph.get_edge_data(cinnabar.ReferenceState(), 'foo')
     assert len(d) == 1
     d = d[0]
     assert d['DG'] == v
@@ -143,7 +157,7 @@ def test_add_RBFE(default_T):
                                    source='ebay', temperature=T)
 
     assert set(m.ligands) == {'foo', 'bar'}
-    d = m.graph.get_edge_data('foo', 'bar')
+    d = m._graph.get_edge_data('foo', 'bar')
     assert len(d) == 1
     d = d[0]
     assert d['DG'] == v
@@ -166,7 +180,7 @@ def test_generate_absolute_values(example_map, ref_mle_results):
     example_map.generate_absolute_values()
 
     for e, (y_ref, yerr_ref) in ref_mle_results.items():
-        data = example_map.graph.get_edge_data(cinnabar.ReferenceState(label='MLE'), e)
+        data = example_map._graph.get_edge_data(cinnabar.ReferenceState(label='MLE'), e)
         # grab the dict containing MLE data
         for _, d in data.items():
             if d['source'] == 'MLE':

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -208,3 +208,20 @@ def test_to_dataframe(example_map):
     assert abs_df2.shape == (72, 5)
     assert abs_df2.loc[abs_df2.computational].shape == (36, 5)
     assert abs_df2.loc[~abs_df2.computational].shape == (36, 5)
+
+
+def test_to_networkx(example_map):
+    g = example_map.to_networkx()
+
+    assert g
+    assert isinstance(g, nx.MultiDiGraph)
+    # should have (exptl + comp edges) * 2
+    assert len(g.edges) == 2 * (36 + 58)
+
+
+def test_from_networkx(example_map):
+    g = example_map.to_networkx()
+
+    m2 = cinnabar.FEMap.from_networkx(g)
+
+    assert example_map == m2

--- a/cinnabar/tests/test_measurements.py
+++ b/cinnabar/tests/test_measurements.py
@@ -14,6 +14,33 @@ def test_ground():
     assert g3 == g4
 
 
+def test_measurement_hash():
+    m1 = cinnabar.Measurement(
+        labelA='foo', labelB='bar',
+        DG=0.1 * unit.kilocalorie_per_mole,
+        uncertainty=0.01 * unit.kilocalorie_per_mole,
+        computational=True,
+    )
+    m1a = cinnabar.Measurement(
+        labelA='foo', labelB='bar',
+        DG=0.1 * unit.kilocalorie_per_mole,
+        uncertainty=0.01 * unit.kilocalorie_per_mole,
+        computational=True,
+    )
+    m2 = cinnabar.Measurement(
+        labelA='foo', labelB='bar',
+        DG=0.11 * unit.kilocalorie_per_mole,
+        uncertainty=0.01 * unit.kilocalorie_per_mole,
+        computational=False,
+    )
+
+    thing = set([m1, m1a, m2])
+
+    assert len(thing) == 2
+    assert m1 in thing
+    assert m2 in thing
+
+
 @pytest.mark.parametrize('Ki,uncertainty,dG,dG_uncertainty,label,temp', [
     [100 * unit.nanomolar, 10 * unit.nanomolar, -9.55 * unit.kilocalorie_per_mole,
      0.059 * unit.kilocalorie_per_mole, 'lig', 298.15 * unit.kelvin],


### PR DESCRIPTION
fixes #110 

This PR hides the internal representation of a FEMap object (currently a nx MultiDiGraph) to allow future flexibility in choosing an optimal backend for this representation.

Instead the current implementation is exposed via a `FEMap.to/from_networkx` method, functions operating on an FEMap can use this to access the data indirectly.

Future representations/solvers working on those backends can be added via more to/from methods.