### PR TITLE
Fix DG and DDG spacing in plots

### DIFF
--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -17,7 +17,7 @@ def _master_plot(
     yerr: Optional[np.ndarray] = None,
     method_name: str = "",
     target_name: str = "",
-    quantity: str = r"$\Delta \Delta$ G",
+    quantity: str = r"$\Delta\Delta$G",
     xlabel: str = "Experimental",
     ylabel: str = "Calculated",
     units: str = r"$\mathrm{kcal\,mol^{-1}}$",
@@ -90,7 +90,7 @@ def _master_plot(
     axis_padding : float, default = 0.5
         padding to add to maximum axis value and subtract from the minimum axis value
     xy_lim : list, default []
-        contains the minimium and maximum values to use for the x and y axes. if specified, axis_padding is ignored
+        contains the minimum and maximum values to use for the x and y axes. if specified, axis_padding is ignored
     font_sizes : dict, default {"title": 12, "labels": 9, "other": 12}
         font sizes to use for the title ("title"), the data labels ("labels"), and the rest of the plot ("other")
     bootstrap_x_uncertainty : bool, default False
@@ -455,7 +455,7 @@ def plot_DGs(
             yerr=yerr,
             origins=False,
             statistics=["RMSE", "MUE", "R2", "rho"],
-            quantity=r"$\Delta$ G",
+            quantity=r"$\Delta$G",
             title=title,
             method_name=method_name,
             target_name=target_name,


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.
Remove the extra space in the axis labels for DG and DDG plots.
Before 
<img width="371" height="377" alt="image" src="https://github.com/user-attachments/assets/ec89386a-b1d2-4b5c-ace9-87350cff6e0a" />
After 
<img width="340" height="358" alt="image" src="https://github.com/user-attachments/assets/9877a8a3-289f-436c-96c3-929c2ac7ec38" />

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Checklist
- [ ] Added a ``news`` entry for new features, bug fixes, or other user facing changes.

## Status
- [x] Ready to go

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.
