### PR TITLE
Add ECDF plots based on industry benchmarks

### DIFF
--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -587,7 +587,7 @@ def ecdf_plot(
     ylabel: str = "Cumulative Probability",
     figsize: float | tuple[float, float] = 4,
     colors: list[str] | None = None,
-    ecdf_kwargs=None,
+    ecdf_kwargs: dict[str, Any] | None = None,
     filename: str | None = None,
 ) -> plt.Figure:
     r"""

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -704,6 +704,11 @@ def ecdf_plot_DDGs(
     -----
     We assume that the graphs have edges with 'calc_DDG' and 'exp_DDG' attributes. If any edges are missing an experimental value,
     they will be skipped in the absolute error calculation.
+
+    Raises
+    ------
+    ValueError
+        If any edges are missing a calculated DDG value.
     """
     # extract the edgewise absolute errors for each graph
     datasets = {}
@@ -714,7 +719,10 @@ def ecdf_plot_DDGs(
 
         # if the experimental value is missing, add a nan so we can filter it out
         x = np.array([x[2].get("exp_DDG", np.nan) for x in graph.edges(data=True)])
-        y = np.array([x[2]["calc_DDG"] for x in graph.edges(data=True)])
+        y = np.array([x[2].get("calc_DDG", np.nan) for x in graph.edges(data=True)])
+        # if any calculated values are missing raise an error
+        if np.any(np.isnan(y)) or y.size == 0:
+            raise ValueError(f"Graph with label {label} has edges with missing calculated DDG values, which should be stored as `calc_DDG`.")
         # filter out edges with missing experimental values
         mask = ~np.isnan(x)
         x = x[mask]
@@ -767,6 +775,11 @@ def ecdf_plot_DGs(
     -----
     We assume that the graphs have nodes with 'calc_DG' and 'exp_DG' attributes. The absolute errors are calculated after centering both
     calculated and experimental values around zero.
+
+    Raises
+    ------
+    ValueError
+        If any nodes are missing a calculated DG value.
     """
     # extract the nodewise absolute errors for each graph
     datasets = {}
@@ -777,7 +790,10 @@ def ecdf_plot_DGs(
 
         # if the experimental value is missing, add a nan so we can filter it out
         x = np.array([node[1].get("exp_DG", np.nan) for node in graph.nodes(data=True)])
-        y = np.array([node[1]["calc_DG"] for node in graph.nodes(data=True)])
+        y = np.array([node[1].get("calc_DG", np.nan) for node in graph.nodes(data=True)])
+        # if any nodes are missing calculated values raise an error
+        if np.any(np.isnan(y)) or y.size == 0:
+            raise ValueError(f"Graph with label {label} has nodes with missing calculated DG values, which should be stored as `calc_DG`.")
         # filter out nodes with missing experimental values
         mask = ~np.isnan(x)
         x = x[mask]
@@ -832,6 +848,11 @@ def ecdf_plot_all_DDGs(
     -----
     We assume that the graphs have nodes with 'calc_DG' and 'exp_DG' attributes. If any nodes are missing an experimental value,
     they will be skipped in the absolute error calculation.
+
+    Raises
+    ------
+    ValueError
+        If any nodes are missing a calculated DG value.
     """
     # extract the all-to-all absolute errors for each graph
     datasets = {}
@@ -844,7 +865,10 @@ def ecdf_plot_all_DDGs(
 
         # if the experimental value is missing, add a nan so we can filter it out
         exp = np.array([node[1].get("exp_DG", np.nan) for node in nodes])
-        calc = np.array([node[1]["calc_DG"] for node in nodes])
+        calc = np.array([node[1].get("calc_DG", np.nan) for node in nodes])
+        # if any nodes are missing calculated values raise an error
+        if np.any(np.isnan(calc)) or calc.size == 0:
+            raise ValueError(f"Graph with label {label} has nodes with missing calculated DG values, which should be stored as `calc_DG`.")
         # filter out nodes with missing experimental values
         mask = ~np.isnan(exp)
         exp = exp[mask]

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -6,7 +6,9 @@ import networkx as nx
 import numpy as np
 from adjustText import adjust_text
 
+from cinnabar.femap import FEMap
 from cinnabar import plotlying, stats
+import seaborn as sns
 
 
 def _master_plot(
@@ -574,3 +576,268 @@ def plot_all_DDGs(
             statistic_type=statistic_type,
             **kwargs,
         )
+
+
+def ecdf_plot(
+    datasets: dict[str, np.ndarray],
+    title: str | None = "ECDF of Absolute Errors",
+    xlabel: str = "Pairwise",
+    quantity: str = r"$|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$",
+    units: str = r"$\mathrm{kcal\,mol^{-1}}$",
+    ylabel: str = "Cumulative Probability",
+    figsize: float | tuple[float, float] = 4,
+    colors: list[str] | None = None,
+    ecdf_kwargs=None,
+    filename: str | None = None,
+) -> plt.Figure:
+    """
+    Plot ECDFs for one or more datasets. Where the dataset is a flat array of absolute errors.
+
+    Parameters
+    ----------
+    datasets : dict[str, np.ndarray]
+        A dictionary where keys are dataset labels and values are the data arrays.
+    title: str | None, default = "ECDF of Absolute Errors"
+        Title for the plot. If None, no title is set.
+    xlabel : str, default = "Absolute Error"
+        Label for the x-axis.
+    quantity : str, default = r"$\Delta\Delta$G"
+        Metric that is being plotted.
+    units : str, default = r"$\mathrm{kcal\,mol^{-1}}$"
+        Units of the metric being plotted.
+    ylabel : str, default = "Cumulative Probability"
+        Label for the y-axis.
+    figsize : float | tuple[float, float], default = 4
+        Size of the figure.
+    colors : list[str] | None, default = None
+        List of colors for each dataset. If None, default colors are used.
+    ecdf_kwargs : dict, optional
+        Additional keyword arguments to pass to seaborn.ecdfplot.
+    filename : str | None, default = None
+        If provided, the plot will be saved to this filename.
+
+    Returns
+    -------
+    plt.Figure
+        The matplotlib Figure object containing the ECDF plot which can be edited further.
+    """
+    if ecdf_kwargs is None:
+        ecdf_kwargs = {}
+
+    if not datasets:
+        raise ValueError("At least one dataset is required to plot an ECDF.")
+
+    if not isinstance(figsize, tuple):
+        figsize = (figsize, figsize)
+    fig, axs = plt.subplots(figsize=figsize)
+
+    # make the default ecdf_kwargs for the plot
+    default_kwargs = {
+        "ax": axs,
+        "linewidth": 2,
+    }
+    default_kwargs.update(ecdf_kwargs)
+
+    # Iterate over the dictionary to plot ECDFs
+    for i, (label, data) in enumerate(datasets.items()):
+        # Pick a color for the dataset if specified
+        color = colors[i] if colors and i < len(colors) else None
+        if color:
+            default_kwargs["color"] = color
+
+        sns.ecdfplot(data, label=label, **default_kwargs)
+
+    if title is not None:
+        plt.title(title, fontsize=14)
+
+    plt.xlabel(f"{xlabel} {quantity} ({units})", fontsize=12)
+    plt.ylabel(ylabel, fontsize=12)
+    plt.grid(alpha=0.3)
+    plt.xlim(left=0)
+    plt.legend()
+    # add gridlines to help identify 1, 2 kcal/mol errors
+    plt.grid(alpha=0.3)
+    plt.tight_layout()
+    if filename is not None:
+        plt.savefig(filename, bbox_inches="tight", dpi=300)
+    return fig
+
+
+def ecdf_plot_DDGs(
+    graphs: list[FEMap | nx.MultiDiGraph],
+    labels: list[str],
+    title: str | None = "ECDF of Absolute Errors",
+    filename: str | None = None,
+    **kwargs,
+) -> plt.Figure:
+    """
+    Plot ECDF of absolute errors for edgewise relative free energies in a graph.
+
+    Parameters
+    ----------
+    graphs: list[FEMap | nx.MultiDiGraph]
+        A list of graph objects with relative free energy edges.
+    labels: list[str]
+        A list of labels corresponding to each graph, these will be used in the legend.
+    title : str | None, default = "ECDF of Absolute Errors"
+        Title for the plot. If None, no title is set.
+    filename : str | None, default = None
+        If provided, the plot will be saved to this filename.
+    **kwargs
+        Additional keyword arguments to pass to `ecdf_plot`.
+
+    Returns
+    -------
+    plt.Figure
+        The matplotlib Figure object containing the ECDF plot which can be edited further.
+
+    Notes
+    -----
+    We assume that the graphs have edges with 'calc_DDG' and 'exp_DDG' attributes. If any edges are missing an experimental value,
+    they will be skipped in the absolute error calculation.
+    """
+    # extract the edgewise absolute errors for each graph
+    datasets = {}
+    for graph, label in zip(graphs, labels):
+        # handle the case where a FEMap is provided
+        if isinstance(graph, FEMap):
+            graph = graph.to_legacy_graph()
+
+        x = np.array([x[2]["exp_DDG"] for x in graph.edges(data=True)])
+        y = np.array([x[2]["calc_DDG"] for x in graph.edges(data=True)])
+        abs_errors = np.abs(y - x)
+        datasets[label] = abs_errors
+
+    fig = ecdf_plot(
+        datasets,
+        title=title,
+        filename=filename,
+        xlabel="Edgewise",
+        **kwargs,
+    )
+    return fig
+
+
+def ecdf_plot_DGs(
+    graphs: list[FEMap | nx.MultiDiGraph],
+    labels: list[str],
+    title: str | None = "ECDF of Absolute Errors",
+    filename: str | None = None,
+    **kwargs,
+) -> plt.Figure:
+    """
+    Plot ECDF of absolute errors for nodewise absolute free energies in a graph.
+
+    Parameters
+    ----------
+    graphs: list[FEMap | nx.MultiDiGraph]
+        A list of graph objects with relative free energy edges.
+    labels: list[str]
+        A list of labels corresponding to each graph, these will be used in the legend.
+    title : str | None, default = "ECDF of Absolute Errors"
+        Title for the plot. If None, no title is set.
+    filename : str | None, default = None
+        If provided, the plot will be saved to this filename.
+    **kwargs
+        Additional keyword arguments to pass to `ecdf_plot`.
+
+    Returns
+    -------
+    plt.Figure
+        The matplotlib Figure object containing the ECDF plot which can be edited further.
+
+    Notes
+    -----
+    We assume that the graphs have nodes with 'calc_DG' and 'exp_DG' attributes. The absolute errors are calculated after centering both
+    calculated and experimental values around zero.
+    """
+    # extract the nodewise absolute errors for each graph
+    datasets = {}
+    for graph, label in zip(graphs, labels):
+        # handle the case where a FEMap is provided
+        if isinstance(graph, FEMap):
+            graph = graph.to_legacy_graph()
+
+        x = np.array([node[1]["exp_DG"] for node in graph.nodes(data=True)])
+        y = np.array([node[1]["calc_DG"] for node in graph.nodes(data=True)])
+        # we need to shift the arrays to both be centered around zero
+        x -= np.mean(x)
+        y -= np.mean(y)
+
+        abs_errors = np.abs(y - x)
+        datasets[label] = abs_errors
+
+    fig = ecdf_plot(
+        datasets,
+        title=title,
+        xlabel="Nodewise",
+        quantity=r"$|\Delta$G$_{calc} - \Delta$G$_{exp}|$",
+        filename=filename,
+        **kwargs,
+    )
+    return fig
+
+
+def ecdf_plot_all_DDGs(
+    graphs: list[FEMap | nx.MultiDiGraph],
+    labels: list[str],
+    title: str | None = "ECDF of Absolute Errors",
+    filename: str | None = None,
+    **kwargs,
+) -> plt.Figure:
+    """
+    Plot ECDF of absolute errors for all-to-all relative free energies calculated from absolute free energies in a graph.
+
+    Parameters
+    ----------
+    graphs: list[FEMap | nx.MultiDiGraph]
+        A list of graph objects with relative free energy edges.
+    labels: list[str]
+        A list of labels corresponding to each graph, these will be used in the legend.
+    title : str | None, default = "ECDF of Absolute Errors"
+        Title for the plot. If None, no title is set.
+    filename : str | None, default = None
+        If provided, the plot will be saved to this filename.
+    **kwargs
+        Additional keyword arguments to pass to `ecdf_plot`.
+
+    Returns
+    -------
+    plt.Figure
+        The matplotlib Figure object containing the ECDF plot which can be edited further.
+
+    Notes
+    -----
+    We assume that the graphs have nodes with 'calc_DG' and 'exp_DG' attributes. If any nodes are missing an experimental value,
+    they will be skipped in the absolute error calculation.
+    """
+    # extract the all-to-all absolute errors for each graph
+    datasets = {}
+    for graph, label in zip(graphs, labels):
+        # handle the case where a FEMap is provided
+        if isinstance(graph, FEMap):
+            graph = graph.to_legacy_graph()
+
+        nodes = graph.nodes(data=True)
+
+        exp = np.array([node[1]["exp_DG"] for node in nodes])
+        calc = np.array([node[1]["calc_DG"] for node in nodes])
+        # do all to plot_all we are taking the abs error so we only need the error once per pair
+        errors = []
+        for a, b in itertools.combinations(range(len(calc)), 2):
+            # transform a -> b has a DDG of calc[b] - calc[a]
+            calc_ddg = calc[b] - calc[a]
+            exp_ddg = exp[b] - exp[a]
+            errors.append(calc_ddg - exp_ddg)
+
+
+        datasets[label] = np.abs(errors)
+
+    fig = ecdf_plot(
+        datasets,
+        title=title,
+        xlabel="Pairwise",
+        filename=filename,
+        **kwargs,
+    )
+    return fig

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -652,7 +652,6 @@ def ecdf_plot(
 
     plt.xlabel(f"{xlabel} {quantity} ({units})", fontsize=12)
     plt.ylabel(ylabel, fontsize=12)
-    plt.grid(alpha=0.3)
     plt.xlim(left=0)
     plt.legend()
     # add gridlines to help identify 1, 2 kcal/mol errors

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Optional, Union, Literal
+from typing import Any, Literal, Optional, Union
 
 import matplotlib.pylab as plt
 import networkx as nx

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -722,7 +722,9 @@ def ecdf_plot_DDGs(
         y = np.array([x[2].get("calc_DDG", np.nan) for x in graph.edges(data=True)])
         # if any calculated values are missing raise an error
         if np.any(np.isnan(y)) or y.size == 0:
-            raise ValueError(f"Graph with label {label} has edges with missing calculated DDG values, which should be stored as `calc_DDG`.")
+            raise ValueError(
+                f"Graph with label {label} has edges with missing calculated DDG values, which should be stored as `calc_DDG`."
+            )
         # filter out edges with missing experimental values
         mask = ~np.isnan(x)
         x = x[mask]
@@ -793,7 +795,9 @@ def ecdf_plot_DGs(
         y = np.array([node[1].get("calc_DG", np.nan) for node in graph.nodes(data=True)])
         # if any nodes are missing calculated values raise an error
         if np.any(np.isnan(y)) or y.size == 0:
-            raise ValueError(f"Graph with label {label} has nodes with missing calculated DG values, which should be stored as `calc_DG`.")
+            raise ValueError(
+                f"Graph with label {label} has nodes with missing calculated DG values, which should be stored as `calc_DG`."
+            )
         # filter out nodes with missing experimental values
         mask = ~np.isnan(x)
         x = x[mask]
@@ -868,7 +872,9 @@ def ecdf_plot_all_DDGs(
         calc = np.array([node[1].get("calc_DG", np.nan) for node in nodes])
         # if any nodes are missing calculated values raise an error
         if np.any(np.isnan(calc)) or calc.size == 0:
-            raise ValueError(f"Graph with label {label} has nodes with missing calculated DG values, which should be stored as `calc_DG`.")
+            raise ValueError(
+                f"Graph with label {label} has nodes with missing calculated DG values, which should be stored as `calc_DG`."
+            )
         # filter out nodes with missing experimental values
         mask = ~np.isnan(exp)
         exp = exp[mask]

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -4,11 +4,11 @@ from typing import Optional, Union
 import matplotlib.pylab as plt
 import networkx as nx
 import numpy as np
+import seaborn as sns
 from adjustText import adjust_text
 
-from cinnabar.femap import FEMap
 from cinnabar import plotlying, stats
-import seaborn as sns
+from cinnabar.femap import FEMap
 
 
 def _master_plot(
@@ -590,7 +590,7 @@ def ecdf_plot(
     ecdf_kwargs=None,
     filename: str | None = None,
 ) -> plt.Figure:
-    """
+    r"""
     Plot ECDFs for one or more datasets. Where the dataset is a flat array of absolute errors.
 
     Parameters
@@ -829,7 +829,6 @@ def ecdf_plot_all_DDGs(
             calc_ddg = calc[b] - calc[a]
             exp_ddg = exp[b] - exp[a]
             errors.append(calc_ddg - exp_ddg)
-
 
         datasets[label] = np.abs(errors)
 

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -665,7 +665,7 @@ def ecdf_plot(
 def ecdf_plot_DDGs(
     graphs: list[FEMap | nx.MultiDiGraph],
     labels: list[str],
-    title: str | None = "ECDF of Absolute Errors",
+    title: str | None = "ECDF of Edgewise Absolute Errors",
     filename: str | None = None,
     **kwargs,
 ) -> plt.Figure:

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Optional, Union, Any
+from typing import Any, Optional, Union
 
 import matplotlib.pylab as plt
 import networkx as nx

--- a/cinnabar/tests/conftest.py
+++ b/cinnabar/tests/conftest.py
@@ -3,6 +3,7 @@ from importlib import resources
 import pytest
 
 from cinnabar import FEMap
+from openff.units import unit
 
 
 @pytest.fixture(scope="session")
@@ -477,3 +478,34 @@ def ref_mle_results():
         "CAT-4k": (1.9341200732632289, 0.1050229267217769),
         "CAT-4p": (-0.3889609918160919, 0.09895523959628322),
     }
+
+
+@pytest.fixture()
+def ecdf_femap_missing_exp_data():
+    """
+    FEMap with some missing experimental data for testing ECDF plotting with missing data
+    """
+    fe_map = FEMap()
+    fe_map.add_relative_calculation(
+        labelA="ligand1",
+        labelB="ligand2",
+        value=2.0 * unit.kilocalories_per_mole,
+        uncertainty=0.1 * unit.kilocalories_per_mole
+    )
+    fe_map.add_relative_calculation(
+        labelA="ligand2",
+        labelB="ligand3",
+        value=-1.0 * unit.kilocalories_per_mole,
+        uncertainty=0.2 * unit.kilocalories_per_mole
+    )
+    fe_map.add_experimental_measurement(
+        label="ligand1",
+        value=-7.0 * unit.kilocalories_per_mole,
+        uncertainty=0.3 * unit.kilocalories_per_mole
+    )
+    fe_map.add_experimental_measurement(
+        label="ligand2",
+        value=-5.0 * unit.kilocalories_per_mole,
+        uncertainty=0.2 * unit.kilocalories_per_mole
+    )
+    return fe_map

--- a/cinnabar/tests/conftest.py
+++ b/cinnabar/tests/conftest.py
@@ -1,9 +1,9 @@
 from importlib import resources
 
 import pytest
+from openff.units import unit
 
 from cinnabar import FEMap
-from openff.units import unit
 
 
 @pytest.fixture(scope="session")
@@ -490,22 +490,18 @@ def ecdf_femap_missing_exp_data():
         labelA="ligand1",
         labelB="ligand2",
         value=2.0 * unit.kilocalories_per_mole,
-        uncertainty=0.1 * unit.kilocalories_per_mole
+        uncertainty=0.1 * unit.kilocalories_per_mole,
     )
     fe_map.add_relative_calculation(
         labelA="ligand2",
         labelB="ligand3",
         value=-1.0 * unit.kilocalories_per_mole,
-        uncertainty=0.2 * unit.kilocalories_per_mole
+        uncertainty=0.2 * unit.kilocalories_per_mole,
     )
     fe_map.add_experimental_measurement(
-        label="ligand1",
-        value=-7.0 * unit.kilocalories_per_mole,
-        uncertainty=0.3 * unit.kilocalories_per_mole
+        label="ligand1", value=-7.0 * unit.kilocalories_per_mole, uncertainty=0.3 * unit.kilocalories_per_mole
     )
     fe_map.add_experimental_measurement(
-        label="ligand2",
-        value=-5.0 * unit.kilocalories_per_mole,
-        uncertainty=0.2 * unit.kilocalories_per_mole
+        label="ligand2", value=-5.0 * unit.kilocalories_per_mole, uncertainty=0.2 * unit.kilocalories_per_mole
     )
     return fe_map

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -1,8 +1,8 @@
 import networkx as nx
+import numpy as np
 import pytest
 
-from cinnabar import plotting, FEMap
-import numpy as np
+from cinnabar import FEMap, plotting
 
 
 def test_plot_ecdf_ddgs(fe_map, tmp_path):
@@ -13,9 +13,12 @@ def test_plot_ecdf_ddgs(fe_map, tmp_path):
     # check the axis are labeled correctly
     axes = fig.get_axes()[0]
     assert axes.get_ylabel() == "Cumulative Probability"
-    assert axes.get_xlabel() == "Edgewise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    assert (
+        axes.get_xlabel() == r"Edgewise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    )
     # make sure the file was created
     assert output_file.exists()
+
 
 def test_plot_ecdf_all_ddgs(fe_map, tmp_path):
     """Test ECDF All DDG plotting function."""
@@ -25,7 +28,9 @@ def test_plot_ecdf_all_ddgs(fe_map, tmp_path):
     # check the axis are labeled correctly
     axes = fig.get_axes()[0]
     assert axes.get_ylabel() == "Cumulative Probability"
-    assert axes.get_xlabel() == "Pairwise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    assert (
+        axes.get_xlabel() == r"Pairwise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    )
     # make sure the file was created
     assert output_file.exists()
 
@@ -38,7 +43,7 @@ def test_plot_ecdf_dgs(fe_map, tmp_path):
     # check the axis are labeled correctly
     axes = fig.get_axes()[0]
     assert axes.get_ylabel() == "Cumulative Probability"
-    assert axes.get_xlabel() == "Nodewise $|\Delta$G$_{calc} - \Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    assert axes.get_xlabel() == r"Nodewise $|\Delta$G$_{calc} - \Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
     # make sure the file was created
     assert output_file.exists()
 
@@ -78,12 +83,7 @@ def test_plot_ecdf_no_datasets():
 def test_plot_ecdf_colors(fe_map, tmp_path):
     """Test ECDF plotting function with custom colors."""
     output_file = tmp_path / "test_ecdf_colors.png"
-    fig = plotting.ecdf_plot_DDGs(
-        [fe_map],
-        labels=["Test FE Map"],
-        colors=["#FF5733"],
-        filename=output_file.as_posix()
-    )
+    fig = plotting.ecdf_plot_DDGs([fe_map], labels=["Test FE Map"], colors=["#FF5733"], filename=output_file.as_posix())
     assert fig is not None
     # check the file was created
     assert output_file.exists()

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -1,6 +1,6 @@
+import matplotlib.pylab as plt
 import networkx as nx
 import numpy as np
-import matplotlib.pylab as plt
 import pytest
 from openff.units import unit
 

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -277,6 +277,15 @@ def test_plot_ecdf_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
     assert output_file.exists()
 
 
+@pytest.mark.parametrize("graph", [
+    nx.MultiDiGraph(),
+    nx.MultiDiGraph([(0, 1, {"calc_deltadeltaG": 1.0})]),
+])
+def test_plot_ecdf_ddgs_no_data(graph):
+    with pytest.raises(ValueError, match="Graph with label test has edges with missing calculated DDG values, which should be stored as `calc_DDG`."):
+        plotting.ecdf_plot_DDGs([graph], labels=["test"], filename=None)
+
+
 def test_plot_ecdf_all_ddgs(fe_map, tmp_path):
     """Test ECDF All DDG plotting function."""
     output_file = tmp_path / "test_ecdf_all_ddgs.png"
@@ -308,6 +317,16 @@ def test_plot_ecdf_all_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
     )
     # make sure the file was created
     assert output_file.exists()
+
+
+@pytest.mark.parametrize("graph", [
+    nx.MultiDiGraph(),
+    # graph with nodes but no calculated DDG edges
+    nx.MultiDiGraph([(0, 1, {"some_other_data": 1.0})])
+])
+def test_plot_ecdf_all_ddgs_no_data(graph):
+    with pytest.raises(ValueError, match="Graph with label test has nodes with missing calculated DG values, which should be stored as `calc_DG`."):
+        plotting.ecdf_plot_all_DDGs([graph], labels=["test"], filename=None)
 
 
 @pytest.mark.parametrize("centralising, xlim", [(True, (2.1, 2.2)), (False, (11.5, 11.6))])
@@ -370,3 +389,13 @@ def test_plot_ecdf_colors(fe_map, tmp_path):
     # check that the line color matches the specified color
     line = fig.get_axes()[0].lines[0]
     assert line.get_color() == "#FF5733"
+
+
+@pytest.mark.parametrize("graph", [
+    nx.MultiDiGraph(),
+    # graph with nodes but no calculated DDG edges
+    nx.MultiDiGraph([(0, 1, {"some_other_data": 1.0})])
+])
+def test_plot_ecdf_dgs_no_data(graph):
+    with pytest.raises(ValueError, match="Graph with label test has nodes with missing calculated DG values, which should be stored as `calc_DG`."):
+        plotting.ecdf_plot_DGs([graph], labels=["test"], filename=None)

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -16,6 +16,24 @@ def test_plot_ecdf_ddgs(fe_map, tmp_path):
     assert (
         axes.get_xlabel() == r"Edgewise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
     )
+    assert axes.get_title() == "ECDF of Edgewise Absolute Errors"
+    # make sure the file was created
+    assert output_file.exists()
+
+
+def test_plot_ecdf_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
+    """Test ECDF DDG plotting function with missing experimental data."""
+    output_file = tmp_path / "test_ecdf_ddgs_missing_data.png"
+    fig = plotting.ecdf_plot_DDGs(
+        [ecdf_femap_missing_exp_data], labels=["FE Map with Missing Data"], filename=output_file.as_posix()
+    )
+    assert fig is not None
+    # check the axis are labeled correctly
+    axes = fig.get_axes()[0]
+    assert axes.get_ylabel() == "Cumulative Probability"
+    assert (
+        axes.get_xlabel() == r"Edgewise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    )
     # make sure the file was created
     assert output_file.exists()
 
@@ -31,19 +49,40 @@ def test_plot_ecdf_all_ddgs(fe_map, tmp_path):
     assert (
         axes.get_xlabel() == r"Pairwise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
     )
+    assert axes.get_title() == "ECDF of Pairwise (all-to-all) Absolute Errors"
     # make sure the file was created
     assert output_file.exists()
 
 
-def test_plot_ecdf_dgs(fe_map, tmp_path):
-    """Test ECDF DG plotting function."""
+def test_plot_ecdf_all_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
+    """Test ECDF All DDG plotting function with missing experimental data."""
+    output_file = tmp_path / "test_ecdf_all_ddgs_missing_data.png"
+    fig = plotting.ecdf_plot_all_DDGs(
+        [ecdf_femap_missing_exp_data], labels=["FE Map with Missing Data"], filename=output_file.as_posix()
+    )
+    assert fig is not None
+    # check the axis are labeled correctly
+    axes = fig.get_axes()[0]
+    assert axes.get_ylabel() == "Cumulative Probability"
+    assert (
+        axes.get_xlabel() == r"Pairwise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    )
+    # make sure the file was created
+    assert output_file.exists()
+
+
+@pytest.mark.parametrize("centralising, xlim", [(True, (2.1, 2.2)), (False, (11.5, 11.6))])
+def test_plot_ecdf_dgs(fe_map, tmp_path, centralising, xlim):
+    """Test ECDF DG plotting function with and without centralizing."""
     output_file = tmp_path / "test_ecdf_dgs.png"
-    fig = plotting.ecdf_plot_DGs([fe_map], labels=["Test FE Map"], filename=output_file.as_posix())
+    fig = plotting.ecdf_plot_DGs([fe_map], labels=["Test FE Map"], filename=output_file.as_posix(), centralizing=centralising)
     assert fig is not None
     # check the axis are labeled correctly
     axes = fig.get_axes()[0]
     assert axes.get_ylabel() == "Cumulative Probability"
     assert axes.get_xlabel() == r"Nodewise $|\Delta$G$_{calc} - \Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    assert axes.get_title() == "ECDF of Nodewise Absolute Errors"
+    assert xlim[0] <= axes.get_xlim()[1] <= xlim[1]
     # make sure the file was created
     assert output_file.exists()
 

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -277,12 +277,18 @@ def test_plot_ecdf_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
     assert output_file.exists()
 
 
-@pytest.mark.parametrize("graph", [
-    nx.MultiDiGraph(),
-    nx.MultiDiGraph([(0, 1, {"calc_deltadeltaG": 1.0})]),
-])
+@pytest.mark.parametrize(
+    "graph",
+    [
+        nx.MultiDiGraph(),
+        nx.MultiDiGraph([(0, 1, {"calc_deltadeltaG": 1.0})]),
+    ],
+)
 def test_plot_ecdf_ddgs_no_data(graph):
-    with pytest.raises(ValueError, match="Graph with label test has edges with missing calculated DDG values, which should be stored as `calc_DDG`."):
+    with pytest.raises(
+        ValueError,
+        match="Graph with label test has edges with missing calculated DDG values, which should be stored as `calc_DDG`.",
+    ):
         plotting.ecdf_plot_DDGs([graph], labels=["test"], filename=None)
 
 
@@ -319,13 +325,19 @@ def test_plot_ecdf_all_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
     assert output_file.exists()
 
 
-@pytest.mark.parametrize("graph", [
-    nx.MultiDiGraph(),
-    # graph with nodes but no calculated DDG edges
-    nx.MultiDiGraph([(0, 1, {"some_other_data": 1.0})])
-])
+@pytest.mark.parametrize(
+    "graph",
+    [
+        nx.MultiDiGraph(),
+        # graph with nodes but no calculated DDG edges
+        nx.MultiDiGraph([(0, 1, {"some_other_data": 1.0})]),
+    ],
+)
 def test_plot_ecdf_all_ddgs_no_data(graph):
-    with pytest.raises(ValueError, match="Graph with label test has nodes with missing calculated DG values, which should be stored as `calc_DG`."):
+    with pytest.raises(
+        ValueError,
+        match="Graph with label test has nodes with missing calculated DG values, which should be stored as `calc_DG`.",
+    ):
         plotting.ecdf_plot_all_DDGs([graph], labels=["test"], filename=None)
 
 
@@ -391,11 +403,17 @@ def test_plot_ecdf_colors(fe_map, tmp_path):
     assert line.get_color() == "#FF5733"
 
 
-@pytest.mark.parametrize("graph", [
-    nx.MultiDiGraph(),
-    # graph with nodes but no calculated DDG edges
-    nx.MultiDiGraph([(0, 1, {"some_other_data": 1.0})])
-])
+@pytest.mark.parametrize(
+    "graph",
+    [
+        nx.MultiDiGraph(),
+        # graph with nodes but no calculated DDG edges
+        nx.MultiDiGraph([(0, 1, {"some_other_data": 1.0})]),
+    ],
+)
 def test_plot_ecdf_dgs_no_data(graph):
-    with pytest.raises(ValueError, match="Graph with label test has nodes with missing calculated DG values, which should be stored as `calc_DG`."):
+    with pytest.raises(
+        ValueError,
+        match="Graph with label test has nodes with missing calculated DG values, which should be stored as `calc_DG`.",
+    ):
         plotting.ecdf_plot_DGs([graph], labels=["test"], filename=None)

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -1,0 +1,92 @@
+import networkx as nx
+import pytest
+
+from cinnabar import plotting, FEMap
+import numpy as np
+
+
+def test_plot_ecdf_ddgs(fe_map, tmp_path):
+    """Test ECDF DDG plotting function."""
+    output_file = tmp_path / "test_ecdf_ddgs.png"
+    fig = plotting.ecdf_plot_DDGs([fe_map], labels=["Test FE Map"], filename=output_file.as_posix())
+    assert fig is not None
+    # check the axis are labeled correctly
+    axes = fig.get_axes()[0]
+    assert axes.get_ylabel() == "Cumulative Probability"
+    assert axes.get_xlabel() == "Edgewise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    # make sure the file was created
+    assert output_file.exists()
+
+def test_plot_ecdf_all_ddgs(fe_map, tmp_path):
+    """Test ECDF All DDG plotting function."""
+    output_file = tmp_path / "test_ecdf_all_ddgs.png"
+    fig = plotting.ecdf_plot_all_DDGs([fe_map], labels=["Test FE Map"], filename=output_file.as_posix())
+    assert fig is not None
+    # check the axis are labeled correctly
+    axes = fig.get_axes()[0]
+    assert axes.get_ylabel() == "Cumulative Probability"
+    assert axes.get_xlabel() == "Pairwise $|\Delta\Delta$G$_{calc} - \Delta\Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    # make sure the file was created
+    assert output_file.exists()
+
+
+def test_plot_ecdf_dgs(fe_map, tmp_path):
+    """Test ECDF DG plotting function."""
+    output_file = tmp_path / "test_ecdf_dgs.png"
+    fig = plotting.ecdf_plot_DGs([fe_map], labels=["Test FE Map"], filename=output_file.as_posix())
+    assert fig is not None
+    # check the axis are labeled correctly
+    axes = fig.get_axes()[0]
+    assert axes.get_ylabel() == "Cumulative Probability"
+    assert axes.get_xlabel() == "Nodewise $|\Delta$G$_{calc} - \Delta$G$_{exp}|$ ($\mathrm{kcal\,mol^{-1}}$)"
+    # make sure the file was created
+    assert output_file.exists()
+
+
+def test_plot_ecdf_ddgs_multiple(fe_map, tmp_path):
+    """Test ECDF DDG plotting function with multiple FE maps."""
+    output_file = tmp_path / "test_ecdf_ddgs_multiple.png"
+    # Create a second FE map for testing
+    # add gaussian noise to the first map to create a second map
+    graph = nx.MultiDiGraph()
+    for a, b, data in fe_map.to_networkx().edges(data=True):
+        new_data = data.copy()
+        if data["source"] != "reverse" and data["computational"]:
+            # add noise to the result
+            new_result = data["DG"] + np.random.normal(0, data["uncertainty"].m) * data["DG"].u
+            new_data["DG"] = new_result
+            graph.add_edge(a, b, **new_data)
+            # and add the reverse edge
+            rev_data = new_data.copy()
+            rev_data["source"] = "reverse"
+            rev_data["DG"] = -new_data["DG"]
+            graph.add_edge(b, a, **rev_data)
+        else:
+            graph.add_edge(a, b, **data)
+    fe_map_2 = FEMap.from_networkx(graph)
+    fig = plotting.ecdf_plot_DDGs([fe_map, fe_map_2], labels=["FE Map 1", "FE Map 2"], filename=output_file.as_posix())
+    assert fig is not None
+    # check the file was created
+    assert output_file.exists()
+
+
+def test_plot_ecdf_no_datasets():
+    with pytest.raises(ValueError, match="At least one dataset is required to plot an ECDF."):
+        plotting.ecdf_plot({})
+
+
+def test_plot_ecdf_colors(fe_map, tmp_path):
+    """Test ECDF plotting function with custom colors."""
+    output_file = tmp_path / "test_ecdf_colors.png"
+    fig = plotting.ecdf_plot_DDGs(
+        [fe_map],
+        labels=["Test FE Map"],
+        colors=["#FF5733"],
+        filename=output_file.as_posix()
+    )
+    assert fig is not None
+    # check the file was created
+    assert output_file.exists()
+    # check that the line color matches the specified color
+    line = fig.get_axes()[0].lines[0]
+    assert line.get_color() == "#FF5733"

--- a/cinnabar/tests/test_plotting.py
+++ b/cinnabar/tests/test_plotting.py
@@ -75,7 +75,9 @@ def test_plot_ecdf_all_ddgs_missing_data(tmp_path, ecdf_femap_missing_exp_data):
 def test_plot_ecdf_dgs(fe_map, tmp_path, centralising, xlim):
     """Test ECDF DG plotting function with and without centralizing."""
     output_file = tmp_path / "test_ecdf_dgs.png"
-    fig = plotting.ecdf_plot_DGs([fe_map], labels=["Test FE Map"], filename=output_file.as_posix(), centralizing=centralising)
+    fig = plotting.ecdf_plot_DGs(
+        [fe_map], labels=["Test FE Map"], filename=output_file.as_posix(), centralizing=centralising
+    )
     assert fig is not None
     # check the axis are labeled correctly
     axes = fig.get_axes()[0]

--- a/news/ecdf_plots.rst
+++ b/news/ecdf_plots.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* added ECDF plotting functionality to visualize the empirical cumulative distribution function of predicted vs experimental absolute, relative and all-to-all pairwise binding free energies `PR#172 <https://github.com/OpenFreeEnergy/cinnabar/pull/172>`_.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
## Description
Fixes #163 by adding a general ecdf plot function which can compare multipule datasets and convence functions which can plot directly from an FEMap or legacy graph.

API example 
```python
# given two FEMaps each with experimental data plot the ddgs
from cinnabar import plotting

fig = plotting.ecdf_plot_DDGs(graphs=[femap_1, femap_2], labels=["FE Map 1", "FE Map 2"], filename="ecdf_ddg_comp.png")
```

An example comparison plot
<img width="1168" height="1164" alt="test_ddgs_multiple" src="https://github.com/user-attachments/assets/324f60ae-09df-4d6f-9e9f-3074f9706c73" />


## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] add docs once happy with the API

## Questions
- [ ] Do we want to change all plotting functions to acept FEMaps and move towards not using the legacy graph API?

## Checklist
- [ ] Added a ``news`` entry for new features, bug fixes, or other user facing changes.

## Status
- [x] Ready to go

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.
