### PR TITLE
Raise an error when we have repeated edge results

### DIFF
--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -504,6 +504,8 @@ class FEMap:
         """
         # reduces to nx.DiGraph
         g = nx.DiGraph()
+        # the MLE method can only use a single result per edge, we need to raise and error if we have repeats or bidirectional results
+        edges_seen = []
         # add DDG values from computational graph
         for a, b, d in self._graph.edges(data=True):
             if not d["computational"]:
@@ -512,8 +514,16 @@ class FEMap:
                 continue
             if d["source"] == "reverse":  # skip mirrors
                 continue
+            edge_name = tuple(sorted([a, b]))
+            if edge_name in edges_seen:
+                raise ValueError(
+                    f"Multiple edges detected between nodes {a} and {b}. MLE cannot be performed on graphs with multiple "
+                    f"edges between the same nodes. The results should be combined into a single estimate and uncertainty "
+                    f"before performing MLE. See https://cinnabar.openfree.energy/en/latest/concepts/estimators.html#limitations for more details."
+                )
 
             g.add_edge(a, b, calc_DDG=d["DG"].magnitude, calc_dDDG=d["uncertainty"].magnitude)
+            edges_seen.append(edge_name)
         # add DG values from experiment graph
         for node, d in g.nodes(data=True):
             expt = self._graph.get_edge_data(ReferenceState(), node)

--- a/cinnabar/stats.py
+++ b/cinnabar/stats.py
@@ -193,6 +193,19 @@ def mle(graph: nx.DiGraph, factor: str = "f_ij", node_factor: Union[str, None] =
         C[i,j] is the covariance of the free energy estimates of i and j
 
     """
+    # if we have bidirectional edge results we need to raise an error as they can not be used with MLE
+    # track the edges we have seen
+    edges = []
+    for a, b in graph.edges:
+        edge_name = tuple(sorted([a, b]))
+        if edge_name in edges:
+            raise ValueError(
+                f"Multiple edges detected between nodes {a} and {b}. MLE cannot be performed on graphs with multiple "
+                f"edges between the same nodes. The results should be combined into a single estimate and uncertainty "
+                f"before performing MLE. See https://cinnabar.openfree.energy/en/latest/concepts/estimators.html#limitations for more details."
+            )
+        edges.append(edge_name)
+
     N = graph.number_of_nodes()
     if node_factor is None:
         f_ij = form_edge_matrix(graph, factor, action="antisymmetrize")

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -242,6 +242,32 @@ def test_generate_absolute_values_mixed_units():
         m.generate_absolute_values()
 
 
+def test_generate_absolute_values_repeats():
+    """Make sure an error is raised if there are multiple edges between same nodes and we try and use the MLE solver."""
+    fe_map = femap.FEMap()
+    fe_map.add_relative_calculation(
+        "ligA",
+        "ligB",
+        value=-1.0 * unit.kilocalorie_per_mole,
+        uncertainty=0.1 * unit.kilocalorie_per_mole,
+    )
+    # add a repeated edge
+    fe_map.add_relative_calculation(
+        "ligA",
+        "ligB",
+        value=-1.2 * unit.kilocalorie_per_mole,
+        uncertainty=0.2 * unit.kilocalorie_per_mole,
+    )
+    fe_map.add_relative_calculation(
+        "ligB",
+        "ligC",
+        value=-4.0 * unit.kilocalorie_per_mole,
+        uncertainty=0.2 * unit.kilocalorie_per_mole,
+    )
+    with pytest.raises(ValueError, match="Multiple edges detected between nodes ligA and ligB."):
+        fe_map.generate_absolute_values()
+
+
 def test_to_dataframe(example_map):
     abs_df = example_map.get_absolute_dataframe()
     rel_df = example_map.get_relative_dataframe()

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -124,6 +124,17 @@ def test_mle_relative():
         )
 
 
+def test_mle_bidirectional_edges():
+    """Make sure an error is raised if there are repeated edges in the graph."""
+    graph = nx.DiGraph()
+    graph.add_edge(0, 1, f_ij=1.0, f_dij=0.5)
+    graph.add_edge(1, 0, f_ij=-2.0, f_dij=0.5)  # repeated edge
+
+    with pytest.raises(ValueError, match="Multiple edges detected between nodes 1 and 0."):
+        stats.mle(graph, factor="f_ij", node_factor="f_i")
+
+
+
 def test_correlation_positive(example_data):
     """
     Test that the absolute DG plots have the correct signs,

--- a/cinnabar/tests/test_stats.py
+++ b/cinnabar/tests/test_stats.py
@@ -134,7 +134,6 @@ def test_mle_bidirectional_edges():
         stats.mle(graph, factor="f_ij", node_factor="f_i")
 
 
-
 def test_correlation_positive(example_data):
     """
     Test that the absolute DG plots have the correct signs,


### PR DESCRIPTION
## Description
Fixes #133 & #136 by raising an error if we find repeated or bidirectional results in the input graph when trying to compute the absolute values with the MLE method. This now points the users to the docs and advises them to combine the results in some way rather than doing this automatically. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Checklist
- [ ] Added a ``news`` entry for new features, bug fixes, or other user facing changes.

## Status
- [ ] Ready to go

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.
