### PR TITLE
Align all dataframes

### DIFF
--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -376,7 +376,7 @@ class FEMap:
             if exp_1 is not None and exp_2 is not None:
                 # if we have both, we can add the experimental DDG and uncertainty to the dataframe
                 exp_ddg = exp_2["DG"].to(kcpm).m - exp_1["DG"].to(kcpm).m
-                exp_uncertainty = (exp_1["uncertainty"].to(kcpm).m**2 + exp_2["uncertainty"].to(kcpm).m**2) ** 0.5
+                exp_uncertainty = (exp_1["uncertainty"].to(kcpm).m ** 2 + exp_2["uncertainty"].to(kcpm).m ** 2) ** 0.5
                 comp_data.append((l1, l2, exp_ddg, exp_uncertainty, "experimental", False))
 
         cols = ["labelA", "labelB", "DDG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -340,42 +340,65 @@ class FEMap:
         self.add_measurement(m)
 
     def get_relative_dataframe(self) -> pd.DataFrame:
-        """Gets a dataframe of all relative results
+        """Get a dataframe of all relative results for all sources including experimental and computational.
 
+        Note
+        ----
         The pandas DataFrame will have the following columns:
         - labelA
         - labelB
-        - DDG
-        - uncertainty
+        - DDG (kcal/mol)
+        - uncertainty (kcal/mol)
         - source
         - computational
+        Only simulated relative results are included for the computational results
+        The dataframe will be sorted by source, computational, labelA, and labelB to ensure consistent ordering of results between sources.
         """
         kcpm = unit.kilocalorie_per_mole
         data = []
+        # store the non-computational results so we can include them in the dataframe for the same edges
+        non_comp_results = {}
         for l1, l2, d in self._graph.edges(data=True):
             if d["source"] == "reverse":
                 continue
-            if isinstance(l1, ReferenceState) or isinstance(l2, ReferenceState):
+            if isinstance(l1, ReferenceState) or isinstance(l2, ReferenceState) and not d["computational"]:
+                label = l2 if isinstance(l1, ReferenceState) else l1
+                non_comp_results[label] = d
                 continue
 
             data.append((l1, l2, d["DG"].to(kcpm).m, d["uncertainty"].to(kcpm).m, d["source"], d["computational"]))
 
+        # for each computational result add the experimental result for the same edge if it exists
+        comp_data = []
+        for l1, l2, *_ in data:
+            exp_1 = non_comp_results.get(l1, None)
+            exp_2 = non_comp_results.get(l2, None)
+            if exp_1 is not None and exp_2 is not None:
+                # if we have both, we can add the experimental DDG and uncertainty to the dataframe
+                exp_ddg = exp_2["DG"].to(kcpm).m - exp_1["DG"].to(kcpm).m
+                exp_uncertainty = (exp_1["uncertainty"].to(kcpm).m**2 + exp_2["uncertainty"].to(kcpm).m**2) ** 0.5
+                comp_data.append((l1, l2, exp_ddg, exp_uncertainty, "experimental", False))
+
         cols = ["labelA", "labelB", "DDG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]
 
-        return pd.DataFrame(
-            data=data,
+        df = pd.DataFrame(
+            data=data + comp_data,
             columns=cols,
         )
+        return df.sort_values(by=["source", "computational", "labelA", "labelB"]).reset_index(drop=True)
 
     def get_absolute_dataframe(self) -> pd.DataFrame:
-        """Get a dataframe of all absolute results
+        """Get a dataframe of all absolute results from all sources.
 
+        Note
+        ----
         The dataframe will have the following columns:
         - label
-        - DG
-        - uncertainty
+        - DG (kcal/mol)
+        - uncertainty (kcal/mol)
         - source
         - computational
+        The dataframe will be sorted by source, computational, and label to ensure consistent ordering of results between sources.
         """
         kcpm = unit.kilocalorie_per_mole
         data = []
@@ -391,10 +414,11 @@ class FEMap:
 
         cols = ["label", "DG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]
 
-        return pd.DataFrame(
+        df = pd.DataFrame(
             data=data,
             columns=cols,
         )
+        return df.sort_values(by=["source", "computational", "label"]).reset_index(drop=True)
 
     @property
     def n_measurements(self) -> int:

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -275,7 +275,11 @@ def test_to_dataframe(example_map):
     rel_df = example_map.get_relative_dataframe()
 
     assert abs_df.shape == (36, 5)
-    assert rel_df.shape == (58, 6)
+    # the dataframe should have the simulated and experimental values
+    assert rel_df.shape == (116, 6)
+    # check the split between the results is correct
+    assert rel_df.loc[rel_df.computational].shape == (58, 6)
+    assert rel_df.loc[~rel_df.computational].shape == (58, 6)
 
     example_map.generate_absolute_values()
 

--- a/news/align_dataframes.rst
+++ b/news/align_dataframes.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The ``FEMMap.get_absolute_dataframe`` and ``FEMap.get_relative_dataframe`` methods now return dataframes in a sorted order of node labes grouped by source flags to enable easier comparisons between sources and with experimental values `PR#192 <https://github.com/OpenFreeEnergy/cinnabar/pull/192>`_.
+* The ``FEMap.get_relative_dataframe`` now also includes experimental differences for the simulated legs in the dataframe to enable easier comparisons between predicted and experimental values `PR#192 <https://github.com/OpenFreeEnergy/cinnabar/pull/192>`_.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/align_dataframes.rst
+++ b/news/align_dataframes.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* The ``FEMMap.get_absolute_dataframe`` and ``FEMap.get_relative_dataframe`` methods now return dataframes in a sorted order of node labes grouped by source flags to enable easier comparisons between sources and with experimental values `PR#192 <https://github.com/OpenFreeEnergy/cinnabar/pull/192>`_.
+* The ``FEMMap.get_absolute_dataframe`` and ``FEMap.get_relative_dataframe`` methods now return dataframes in a sorted order of node labels grouped by source flags to enable easier comparisons between sources and with experimental values `PR#192 <https://github.com/OpenFreeEnergy/cinnabar/pull/192>`_.
 * The ``FEMap.get_relative_dataframe`` now also includes experimental differences for the simulated legs in the dataframe to enable easier comparisons between predicted and experimental values `PR#192 <https://github.com/OpenFreeEnergy/cinnabar/pull/192>`_.
 
 **Deprecated:**


### PR DESCRIPTION
## Description
Building on #187 this aligns the output of the dataframe functions to return ordered outputs with computational and experimental values to make it easier to perform manual calculations of the statistics. 

For the relative dataframe, experimental differences are only added if we have values for both ligands. In cases with missing experimental data, the values will be of different lengths, which will raise an error in the stats functions if the user does not align and filter the data first. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Checklist
- [x] Added a ``news`` entry for new features, bug fixes, or other user facing changes.

## Status
- [x] Ready to go

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.
