### PR TITLE
test python 3.13 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu', 'macos']
+        os: ['ubuntu-latest']
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+        include:
+          - os: "macos-latest"
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ defaults:
 jobs:
   test:
     name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }}"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ["ubuntu-latest"]
         python-version:
           - "3.11"
           - "3.12"


### PR DESCRIPTION
## Description
openfe supports python 3.13 and uses cinnabar, so we should be testing 3.13 here as well.

We should also update the CI matrix to reflect openfe's - we don't need to test every version against every OS.

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.
