### PR TITLE
feat: expose MLE covariance matrix, use it in MLE ddG plot to have proper error propagation

### DIFF
--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -597,6 +597,10 @@ class FEMap:
             for (_, d), f_i, df_i in zip(g.nodes(data=True), f_i_calc, variance):
                 d["calc_DG"] = f_i
                 d["calc_dDG"] = df_i
+
+            # Make sure MLE covariance matrix is available in case one wants to propagate mle_ddG_errors: Var(dG_b - dG_a) = C[b,b] + C[a,a] - 2 C[a,b].
+            g.graph["mle_C"] = C_calc
+            g.graph["mle_node_index"] = {n: i for i, n in enumerate(g.nodes)}
         else:
             warnings.warn("Graph is not connected enough to compute absolute values")
 

--- a/cinnabar/plotting.py
+++ b/cinnabar/plotting.py
@@ -526,6 +526,16 @@ def plot_all_DDGs(
     y_abs = np.asarray([node[1]["calc_DG"] for node in nodes])
     xabserr = np.asarray([node[1]["exp_dDG"] for node in nodes])
     yabserr = np.asarray([node[1]["calc_dDG"] for node in nodes])
+
+    # If the graph is a legacy MLE graph, we use the covariance matrix to propagate uncertainty of
+    # the differences of absolute MLE dGs.
+    mle_C = graph.graph.get("mle_C")
+    mle_node_index = graph.graph.get("mle_node_index")
+    if mle_C is not None and mle_node_index is not None:
+        idx_arr = np.asarray([mle_node_index[n] for n, _ in nodes])
+    else:
+        idx_arr = None
+
     # do all to plot_all
     x_data = []
     y_data = []
@@ -541,7 +551,11 @@ def plot_all_DDGs(
         y = y_abs[a] - y_abs[b]
         y_data.append(y)
         y_data.append(-y)
-        err = (yabserr[a] ** 2 + yabserr[b] ** 2) ** 0.5
+        if mle_C is not None and idx_arr is not None:
+            i, j = idx_arr[a], idx_arr[b]
+            err = (mle_C[i, i] + mle_C[j, j] - 2 * mle_C[i, j]) ** 0.5
+        else:
+            err = (yabserr[a] ** 2 + yabserr[b] ** 2) ** 0.5
         yerr.append(err)
         yerr.append(err)
     x_data_ = np.array(x_data)

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -249,6 +249,31 @@ def test_generate_absolute_values_mixed_units():
         m.generate_absolute_values()
 
 
+def test_to_legacy_graph_mle_covariance_recovers_open_cycle_errors():
+    """In open cycle graph topologies, MLE derived ddGs and their uncertainties should match the input values"""
+    edges = [
+        ("0", "1", 1.0, 2.5),
+        ("0", "2", 2.0, 2.8),
+        ("2", "3", 3.0, 3.1),
+    ]
+    fe_map = femap.FEMap()
+    for a, b, ddg, dddg in edges:
+        fe_map.add_relative_calculation(
+            a, b, ddg * unit.kilocalorie_per_mole, dddg * unit.kilocalorie_per_mole
+        )
+
+    g = fe_map.to_legacy_graph()
+    C = g.graph["mle_C"]
+    node_index = g.graph["mle_node_index"]
+
+    for a, b, ddg, dddg in edges:
+        i, j = node_index[a], node_index[b]
+        mle_ddG = g.nodes[b]["calc_DG"] - g.nodes[a]["calc_DG"]
+        mle_dDDG = (C[i, i] + C[j, j] - 2 * C[i, j]) ** 0.5
+        assert mle_ddG == pytest.approx(ddg)
+        assert mle_dDDG == pytest.approx(dddg)
+
+
 def test_generate_absolute_values_repeats():
     """Make sure an error is raised if there are multiple edges between same nodes and we try and use the MLE solver."""
     fe_map = femap.FEMap()


### PR DESCRIPTION
Fixes #120 

## Description
`FEMap.to_legacy_graph()` only exposes the diagonal of the MLE covariance matrix, therefore any downstream code that uses these errors assume they are uncorrelated (e.g. plot_all_DDGs(), or bootstrap_statistic()) whereas there are not. In issue #120 I've done the same mistake when computing ddGs and associated uncertainties.

## Fix
- `to_legacy_graph()` now saves complete MLE covariance matrix and node index mapping
-  `plot_all_DDGs()` reads the covariance matrix and use it to propagate errors with `C[i,i] + C[j,j] - 2·C[i,j]`

## Test
`test_to_legacy_graph_mle_covariance_recovers_open_cycle_errors` reuses the open cycle described in the mentioned issue to check that one can recover the input ddGs and associated errors from the MLE estimates.

## Out of scope
`stats.bootstrap_statistic` with `include_pred_uncertainty=True` uses independent gaussian noise for each absolute MLE dG, we might want to set correlated noises using the covariance matrix.
