### PR TITLE
Support pIC50 units on dataframes

### DIFF
--- a/cinnabar/conversion.py
+++ b/cinnabar/conversion.py
@@ -82,7 +82,8 @@ def convert_observable(
     if final_type not in valid_types:
         raise ValueError(f"Unknown final_type: {final_type}. Must be one of: {', '.join(valid_types)}")
     # validate that uncertainty is non-negative if provided
-    if uncertainty is not None and uncertainty < 0:
+    # use np.any so the check works for both scalar and array Quantity inputs
+    if uncertainty is not None and np.any(uncertainty.m < 0):
         raise ValueError("Uncertainty must be positive")
 
     # store the conversion functions by (original_type, final_type) in a dictionary for easy lookup

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -65,19 +65,14 @@ def _convert_dg_df_to_pic50(
     """
     missing = [c for c in (value_col, uncertainty_col) if c not in df.columns]
     if missing:
-        raise ValueError(
-            f"Column(s) {missing} not found in dataframe. "
-            f"Available columns: {list(df.columns)}"
-        )
+        raise ValueError(f"Column(s) {missing} not found in dataframe. Available columns: {list(df.columns)}")
     # default units should always be kcal/mol in the FEMap
     values = df[value_col].to_numpy() * _kcalpm
     uncertainties = df[uncertainty_col].to_numpy() * _kcalpm
     converted_values, converted_uncertainties = convert_observable(values, "dg", "pic50", uncertainties, temperature)
     # make sure we do not change the column order the dataframe should feel the same
     col_order = [
-        new_value_col if c == value_col
-        else (new_uncertainty_col if c == uncertainty_col else c)
-        for c in df.columns
+        new_value_col if c == value_col else (new_uncertainty_col if c == uncertainty_col else c) for c in df.columns
     ]
     return df.drop(columns=[value_col, uncertainty_col]).assign(
         **{new_value_col: converted_values.m, new_uncertainty_col: converted_uncertainties.m}

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -552,6 +552,7 @@ class FEMap:
         - ``uncertainty (kcal/mol)`` / ``uncertainty (ΔpIC50)``
         - source
         - computational
+
         The dataframe will be sorted by source, computational, labelA, and labelB to ensure that pairing order is consistent.
         If `symmetrical` is True, the dataframe will include both (labelA, labelB) and (labelB, labelA) for each pair of labels, with opposite signs for DDG and the same uncertainty.
         If an estimator is used to generate the absolute binding affinities from relative results this function attempts

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -63,13 +63,21 @@ def _convert_dg_df_to_pic50(
         Copy of the dataframe with ``value_col`` / ``uncertainty_col`` dropped and the two
         new columns in their place.
     """
+    missing = [c for c in (value_col, uncertainty_col) if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"Column(s) {missing} not found in dataframe. "
+            f"Available columns: {list(df.columns)}"
+        )
     # default units should always be kcal/mol in the FEMap
     values = df[value_col].to_numpy() * _kcalpm
     uncertainties = df[uncertainty_col].to_numpy() * _kcalpm
     converted_values, converted_uncertainties = convert_observable(values, "dg", "pic50", uncertainties, temperature)
     # make sure we do not change the column order the dataframe should feel the same
     col_order = [
-        new_value_col if c == value_col else (new_uncertainty_col if c == uncertainty_col else c) for c in df.columns
+        new_value_col if c == value_col
+        else (new_uncertainty_col if c == uncertainty_col else c)
+        for c in df.columns
     ]
     return df.drop(columns=[value_col, uncertainty_col]).assign(
         **{new_value_col: converted_values.m, new_uncertainty_col: converted_uncertainties.m}
@@ -401,9 +409,9 @@ class FEMap:
 
         Parameters
         ----------
-        observable_type : ANALYSIS_UNITS, optional
+        observable_type : {"dg", "pic50"}, default "dg"
             The observable type to report values in.  Defaults to ``dg`` (kcal/mol).
-            Use ``pic50`` to report ΔpIC50 values.
+            Use ``pic50`` to report DpIC50 values.
         temperature : Quantity, optional
             Temperature used for the unit conversion.  Defaults to 298.15 K.
 
@@ -411,12 +419,12 @@ class FEMap:
         ----
         The pandas DataFrame will have the following columns:
 
-        - labelA
-        - labelB
-        - ``DDG (kcal/mol)`` / ``ΔpIC50`` — depending on ``observable_type``
-        - ``uncertainty (kcal/mol)`` / ``uncertainty (ΔpIC50)``
-        - source
-        - computational
+        - ``labelA``
+        - ``labelB``
+        - ``DDG (kcal/mol)`` / ``DpIC50`` — depending on ``observable_type``
+        - ``uncertainty (kcal/mol)`` / ``uncertainty (unitless)``
+        - ``source``
+        - ``computational``
 
         Only simulated relative results are included for the computational results.
         The dataframe is sorted by source, computational, labelA, and labelB to ensure consistent ordering of results between sources.
@@ -464,8 +472,10 @@ class FEMap:
         # convert if required
         if observable_type.lower() == "pic50":
             df = _convert_dg_df_to_pic50(
-                df, "DDG (kcal/mol)", "uncertainty (kcal/mol)", "ΔpIC50", "uncertainty (ΔpIC50)", temperature
+                df, "DDG (kcal/mol)", "uncertainty (kcal/mol)", "DpIC50", "uncertainty (unitless)", temperature
             )
+        elif observable_type.lower() != "dg":
+            raise ValueError(f"Unknown observable_type: '{observable_type}'")
 
         return df.sort_values(by=["source", "computational", "labelA", "labelB"]).reset_index(drop=True)
 
@@ -478,9 +488,9 @@ class FEMap:
 
         Parameters
         ----------
-        observable_type : ANALYSIS_UNITS, optional
+        observable_type : {"dg", "pic50"}, default "dg"
             The observable type to report values in.  Defaults to ``dg`` (kcal/mol).
-            Use ``pic50`` to report ΔpIC50 values.
+            Use ``pic50`` to report DpIC50 values.
         temperature : Quantity, optional
             Temperature used for the unit conversion.  Defaults to 298.15 K.
 
@@ -488,11 +498,11 @@ class FEMap:
         ----
         The dataframe will have the following columns:
 
-        - label
+        - ``label``
         - ``DG (kcal/mol)`` / ``pIC50`` — depending on ``observable_type``
-        - ``uncertainty (kcal/mol)`` / ``uncertainty (pIC50)``
-        - source
-        - computational
+        - ``uncertainty (kcal/mol)`` / ``uncertainty (unitless)``
+        - ``source``
+        - ``computational``
 
         The dataframe will be sorted by source, computational, and label to ensure consistent ordering of results between sources.
         """
@@ -514,8 +524,10 @@ class FEMap:
 
         if observable_type.lower() == "pic50":
             df = _convert_dg_df_to_pic50(
-                df, "DG (kcal/mol)", "uncertainty (kcal/mol)", "pIC50", "uncertainty (pIC50)", temperature
+                df, "DG (kcal/mol)", "uncertainty (kcal/mol)", "pIC50", "uncertainty (unitless)", temperature
             )
+        elif observable_type.lower() != "dg":
+            raise ValueError(f"Unknown observable_type: '{observable_type}'")
 
         return df.sort_values(by=["source", "computational", "label"]).reset_index(drop=True)
 
@@ -531,9 +543,9 @@ class FEMap:
         ----------
         symmetrical : bool, optional
             If True, include both directions of each pairwise comparison. If False, include only one direction (default is True).
-        observable_type : ANALYSIS_UNITS, optional
+        observable_type : {"dg", "pic50"}, default "dg"
             The observable type to report values in.  Defaults to ``dg`` (kcal/mol).
-            Use ``pic50`` to report ΔpIC50 values.
+            Use ``pic50`` to report DpIC50 values.
         temperature : Quantity, optional
             Temperature used for the unit conversion.  Defaults to 298.15 K.
 
@@ -546,17 +558,17 @@ class FEMap:
         ----
         The dataframe will have the following columns:
 
-        - labelA
-        - labelB
-        - ``DDG (kcal/mol)`` / ``ΔpIC50`` — depending on ``observable_type``
-        - ``uncertainty (kcal/mol)`` / ``uncertainty (ΔpIC50)``
-        - source
-        - computational
+        - ``labelA``
+        - ``labelB``
+        - ``DDG (kcal/mol)`` / ``DpIC50`` — depending on ``observable_type``
+        - ``uncertainty (kcal/mol)`` / ``uncertainty (unitless)``
+        - ``source``
+        - ``computational``
 
         The dataframe will be sorted by source, computational, labelA, and labelB to ensure that pairing order is consistent.
-        If `symmetrical` is True, the dataframe will include both (labelA, labelB) and (labelB, labelA) for each pair of labels, with opposite signs for DDG and the same uncertainty.
+        If ``symmetrical`` is True, the dataframe will include both (labelA, labelB) and (labelB, labelA) for each pair of labels, with opposite signs for DDG and the same uncertainty.
         If an estimator is used to generate the absolute binding affinities from relative results this function attempts
-        to use the covariance_matrix in the uncertainty if available, if not the covariance is set to zero.
+        to use the ``covariance_matrix`` in the uncertainty if available, if not the covariance is set to zero.
         """
         # we need to group by the source and computational labels and then compute the pairwise differences within each group, then concatenate the results together
         df = self.get_absolute_dataframe()
@@ -611,20 +623,22 @@ class FEMap:
             pairwise_dfs.append(pairwise_df)
 
         if not pairwise_dfs:
-            return pd.DataFrame(
+            result = pd.DataFrame(
                 columns=["labelA", "labelB", "DDG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]
             )
-
-        result = (
-            pd.concat(pairwise_dfs)
-            .sort_values(by=["source", "computational", "labelA", "labelB"])
-            .reset_index(drop=True)
-        )
+        else:
+            result = (
+                pd.concat(pairwise_dfs)
+                .sort_values(by=["source", "computational", "labelA", "labelB"])
+                .reset_index(drop=True)
+            )
 
         if observable_type.lower() == "pic50":
             result = _convert_dg_df_to_pic50(
-                result, "DDG (kcal/mol)", "uncertainty (kcal/mol)", "ΔpIC50", "uncertainty (ΔpIC50)", temperature
+                result, "DDG (kcal/mol)", "uncertainty (kcal/mol)", "DpIC50", "uncertainty (unitless)", temperature
             )
+        elif observable_type.lower() != "dg":
+            raise ValueError(f"Unknown observable_type: '{observable_type}'")
 
         return result
 

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -12,7 +12,7 @@ import itertools
 import pathlib
 import warnings
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Hashable, Optional, Union, Literal
+from typing import TYPE_CHECKING, Hashable, Literal, Optional, Union
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -21,8 +21,8 @@ import openff.units
 import pandas as pd
 from openff.units import Quantity, unit
 
-from cinnabar.conversion import convert_observable
 from cinnabar import stats
+from cinnabar.conversion import convert_observable
 from cinnabar.measurements import Measurement, ReferenceState
 
 if TYPE_CHECKING:
@@ -66,19 +66,14 @@ def _convert_dg_df_to_pic50(
     # default units should always be kcal/mol in the FEMap
     values = df[value_col].to_numpy() * _kcalpm
     uncertainties = df[uncertainty_col].to_numpy() * _kcalpm
-    converted_values, converted_uncertainties = convert_observable(
-        values, "dg", "pic50", uncertainties, temperature
-    )
-   # make sure we do not change the column order the dataframe should feel the same
+    converted_values, converted_uncertainties = convert_observable(values, "dg", "pic50", uncertainties, temperature)
+    # make sure we do not change the column order the dataframe should feel the same
     col_order = [
-        new_value_col if c == value_col else (new_uncertainty_col if c == uncertainty_col else c)
-        for c in df.columns
+        new_value_col if c == value_col else (new_uncertainty_col if c == uncertainty_col else c) for c in df.columns
     ]
-    return (
-        df.drop(columns=[value_col, uncertainty_col])
-        .assign(**{new_value_col: converted_values.m, new_uncertainty_col: converted_uncertainties.m})
-        [col_order]
-    )
+    return df.drop(columns=[value_col, uncertainty_col]).assign(
+        **{new_value_col: converted_values.m, new_uncertainty_col: converted_uncertainties.m}
+    )[col_order]
 
 
 def read_csv(filepath: pathlib.Path, units: Optional[openff.units.Quantity] = None) -> dict:

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -12,7 +12,7 @@ import itertools
 import pathlib
 import warnings
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Hashable, Literal, Optional, TypedDict
+from typing import TYPE_CHECKING, Hashable, Literal, Optional, TypedDict, cast
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -69,10 +69,13 @@ def _convert_dg_df_to_pic50(
     values = df[value_col].to_numpy() * _kcalpm
     uncertainties = df[uncertainty_col].to_numpy() * _kcalpm
     converted_values, converted_uncertainties = convert_observable(values, "dg", "pic50", uncertainties, temperature)
+    # update the type of the converted_uncertainties to be a Quantity as we always use non-zero computational uncertainties
+    converted_uncertainties = cast(Quantity, converted_uncertainties)
+
     # make sure we do not change the column order the dataframe should feel the same
-    col_order = [
-        new_value_col if c == value_col else (new_uncertainty_col if c == uncertainty_col else c) for c in df.columns
-    ]
+    col_rename = {value_col: new_value_col, uncertainty_col: new_uncertainty_col}
+    col_order = [col_rename.get(c, c) for c in df.columns]
+
     return df.drop(columns=[value_col, uncertainty_col]).assign(
         **{new_value_col: converted_values.m, new_uncertainty_col: converted_uncertainties.m}
     )[col_order]

--- a/cinnabar/femap.py
+++ b/cinnabar/femap.py
@@ -12,7 +12,7 @@ import itertools
 import pathlib
 import warnings
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Hashable, Optional, Union
+from typing import TYPE_CHECKING, Hashable, Optional, Union, Literal
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -21,6 +21,7 @@ import openff.units
 import pandas as pd
 from openff.units import Quantity, unit
 
+from cinnabar.conversion import convert_observable
 from cinnabar import stats
 from cinnabar.measurements import Measurement, ReferenceState
 
@@ -28,6 +29,56 @@ if TYPE_CHECKING:
     from cinnabar.estimators import Estimator, EstimatorResult  # pragma: no cover
 
 _kcalpm = unit.kilocalorie_per_mole
+
+# Reusable typing alias for unit conversions
+ANALYSIS_UNITS = Literal["dg", "pic50"]
+
+
+def _convert_dg_df_to_pic50(
+    df: pd.DataFrame,
+    value_col: str,
+    uncertainty_col: str,
+    new_value_col: str,
+    new_uncertainty_col: str,
+    temperature: Quantity,
+) -> pd.DataFrame:
+    """Return a copy of the dataframe with the kcal/mol columns replaced by pIC50 columns using the convert_observable function.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe.  ``value_col`` and ``uncertainty_col`` must be present and
+        contain plain floats in kcal/mol.
+    value_col, uncertainty_col : str
+        Names of the columns to convert.
+    new_value_col, new_uncertainty_col : str
+        Column names to use in the returned dataframe.
+    temperature : Quantity
+        Temperature for the conversion (passed to
+        :func:`~cinnabar.conversion.convert_observable`).
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of the dataframe with ``value_col`` / ``uncertainty_col`` dropped and the two
+        new columns in their place.
+    """
+    # default units should always be kcal/mol in the FEMap
+    values = df[value_col].to_numpy() * _kcalpm
+    uncertainties = df[uncertainty_col].to_numpy() * _kcalpm
+    converted_values, converted_uncertainties = convert_observable(
+        values, "dg", "pic50", uncertainties, temperature
+    )
+   # make sure we do not change the column order the dataframe should feel the same
+    col_order = [
+        new_value_col if c == value_col else (new_uncertainty_col if c == uncertainty_col else c)
+        for c in df.columns
+    ]
+    return (
+        df.drop(columns=[value_col, uncertainty_col])
+        .assign(**{new_value_col: converted_values.m, new_uncertainty_col: converted_uncertainties.m})
+        [col_order]
+    )
 
 
 def read_csv(filepath: pathlib.Path, units: Optional[openff.units.Quantity] = None) -> dict:
@@ -346,20 +397,34 @@ class FEMap:
         )
         self.add_measurement(m)
 
-    def get_relative_dataframe(self) -> pd.DataFrame:
+    def get_relative_dataframe(
+        self,
+        observable_type: ANALYSIS_UNITS = "dg",
+        temperature: Quantity = 298.15 * unit.kelvin,
+    ) -> pd.DataFrame:
         """Get a dataframe of all relative results for all sources including experimental and computational.
+
+        Parameters
+        ----------
+        observable_type : ANALYSIS_UNITS, optional
+            The observable type to report values in.  Defaults to ``dg`` (kcal/mol).
+            Use ``pic50`` to report ΔpIC50 values.
+        temperature : Quantity, optional
+            Temperature used for the unit conversion.  Defaults to 298.15 K.
 
         Note
         ----
         The pandas DataFrame will have the following columns:
+
         - labelA
         - labelB
-        - DDG (kcal/mol)
-        - uncertainty (kcal/mol)
+        - ``DDG (kcal/mol)`` / ``ΔpIC50`` — depending on ``observable_type``
+        - ``uncertainty (kcal/mol)`` / ``uncertainty (ΔpIC50)``
         - source
         - computational
-        Only simulated relative results are included for the computational results
-        The dataframe will be sorted by source, computational, labelA, and labelB to ensure consistent ordering of results between sources.
+
+        Only simulated relative results are included for the computational results.
+        The dataframe is sorted by source, computational, labelA, and labelB to ensure consistent ordering of results between sources.
         """
         kcpm = unit.kilocalorie_per_mole
         data = []
@@ -368,16 +433,24 @@ class FEMap:
         for l1, l2, d in self._graph.edges(data=True):
             if d["source"] == "reverse":
                 continue
-            if isinstance(l1, ReferenceState) or isinstance(l2, ReferenceState) and not d["computational"]:
+            # grab only the experimental non-computational results
+            if (isinstance(l1, ReferenceState) or isinstance(l2, ReferenceState)) and not d["computational"]:
                 label = l2 if isinstance(l1, ReferenceState) else l1
                 non_comp_results[label] = d
+                continue
+            # if this is a computational reference state from MLE or ABFE skip it
+            elif (isinstance(l1, ReferenceState) or isinstance(l2, ReferenceState)) and d["computational"]:
                 continue
 
             data.append((l1, l2, d["DG"].to(kcpm).m, d["uncertainty"].to(kcpm).m, d["source"], d["computational"]))
 
         # for each computational result add the experimental result for the same edge if it exists
         comp_data = []
+        # track the experimental edges added we only want one experimental value per-edge
+        seen_edges = set()
         for l1, l2, *_ in data:
+            if (l1, l2) in seen_edges:
+                continue
             exp_1 = non_comp_results.get(l1, None)
             exp_2 = non_comp_results.get(l2, None)
             if exp_1 is not None and exp_2 is not None:
@@ -385,6 +458,7 @@ class FEMap:
                 exp_ddg = exp_2["DG"].to(kcpm).m - exp_1["DG"].to(kcpm).m
                 exp_uncertainty = (exp_1["uncertainty"].to(kcpm).m ** 2 + exp_2["uncertainty"].to(kcpm).m ** 2) ** 0.5
                 comp_data.append((l1, l2, exp_ddg, exp_uncertainty, "experimental", False))
+                seen_edges.add((l1, l2))
 
         cols = ["labelA", "labelB", "DDG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]
 
@@ -392,19 +466,39 @@ class FEMap:
             data=data + comp_data,
             columns=cols,
         )
+        # convert if required
+        if observable_type.lower() == "pic50":
+            df = _convert_dg_df_to_pic50(
+                df, "DDG (kcal/mol)", "uncertainty (kcal/mol)", "ΔpIC50", "uncertainty (ΔpIC50)", temperature
+            )
+
         return df.sort_values(by=["source", "computational", "labelA", "labelB"]).reset_index(drop=True)
 
-    def get_absolute_dataframe(self) -> pd.DataFrame:
+    def get_absolute_dataframe(
+        self,
+        observable_type: ANALYSIS_UNITS = "dg",
+        temperature: Quantity = 298.15 * unit.kelvin,
+    ) -> pd.DataFrame:
         """Get a dataframe of all absolute results from all sources.
+
+        Parameters
+        ----------
+        observable_type : ANALYSIS_UNITS, optional
+            The observable type to report values in.  Defaults to ``dg`` (kcal/mol).
+            Use ``pic50`` to report ΔpIC50 values.
+        temperature : Quantity, optional
+            Temperature used for the unit conversion.  Defaults to 298.15 K.
 
         Note
         ----
         The dataframe will have the following columns:
+
         - label
-        - DG (kcal/mol)
-        - uncertainty (kcal/mol)
+        - ``DG (kcal/mol)`` / ``pIC50`` — depending on ``observable_type``
+        - ``uncertainty (kcal/mol)`` / ``uncertainty (pIC50)``
         - source
         - computational
+
         The dataframe will be sorted by source, computational, and label to ensure consistent ordering of results between sources.
         """
         kcpm = unit.kilocalorie_per_mole
@@ -421,19 +515,32 @@ class FEMap:
 
         cols = ["label", "DG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]
 
-        df = pd.DataFrame(
-            data=data,
-            columns=cols,
-        )
+        df = pd.DataFrame(data=data, columns=cols)
+
+        if observable_type.lower() == "pic50":
+            df = _convert_dg_df_to_pic50(
+                df, "DG (kcal/mol)", "uncertainty (kcal/mol)", "pIC50", "uncertainty (pIC50)", temperature
+            )
+
         return df.sort_values(by=["source", "computational", "label"]).reset_index(drop=True)
 
-    def get_all_to_all_relative_dataframe(self, symmetrical: bool = True) -> pd.DataFrame:
+    def get_all_to_all_relative_dataframe(
+        self,
+        symmetrical: bool = True,
+        observable_type: ANALYSIS_UNITS = "dg",
+        temperature: Quantity = 298.15 * unit.kelvin,
+    ) -> pd.DataFrame:
         """Get a dataframe of the all-to-all pairwise relative results using the absolute DG values.
 
         Parameters
         ----------
         symmetrical : bool, optional
             If True, include both directions of each pairwise comparison. If False, include only one direction (default is True).
+        observable_type : ANALYSIS_UNITS, optional
+            The observable type to report values in.  Defaults to ``dg`` (kcal/mol).
+            Use ``pic50`` to report ΔpIC50 values.
+        temperature : Quantity, optional
+            Temperature used for the unit conversion.  Defaults to 298.15 K.
 
         Returns
         -------
@@ -443,10 +550,11 @@ class FEMap:
         Note
         ----
         The dataframe will have the following columns:
+
         - labelA
         - labelB
-        - DDG (kcal/mol)
-        - uncertainty (kcal/mol)
+        - ``DDG (kcal/mol)`` / ``ΔpIC50`` — depending on ``observable_type``
+        - ``uncertainty (kcal/mol)`` / ``uncertainty (ΔpIC50)``
         - source
         - computational
         The dataframe will be sorted by source, computational, labelA, and labelB to ensure that pairing order is consistent.
@@ -510,11 +618,19 @@ class FEMap:
             return pd.DataFrame(
                 columns=["labelA", "labelB", "DDG (kcal/mol)", "uncertainty (kcal/mol)", "source", "computational"]
             )
-        return (
+
+        result = (
             pd.concat(pairwise_dfs)
             .sort_values(by=["source", "computational", "labelA", "labelB"])
             .reset_index(drop=True)
         )
+
+        if observable_type.lower() == "pic50":
+            result = _convert_dg_df_to_pic50(
+                result, "DDG (kcal/mol)", "uncertainty (kcal/mol)", "ΔpIC50", "uncertainty (ΔpIC50)", temperature
+            )
+
+        return result
 
     @property
     def n_measurements(self) -> int:

--- a/cinnabar/tests/test_conversion.py
+++ b/cinnabar/tests/test_conversion.py
@@ -156,6 +156,10 @@ def test_convert_value_from_ic50(value, uncertainty, temp, output_type, expected
     ],
 )
 def test_convert_value_from_pic50(value, uncertainty, temp, output_type, expected_value, expected_uncertainty):
+    d = unit("dimensionless")
+    value *= d
+    if uncertainty is not None:
+        uncertainty *= d
     converted_value, converted_error = conversion.convert_observable(
         value=value,
         original_type="pic50",

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -1,3 +1,4 @@
+import re
 import json
 
 import matplotlib.pyplot as plt
@@ -372,8 +373,8 @@ def test_to_relative_dataframe_pic50(example_map, dataframe_func):
     assert rel_pci50.columns.tolist() == [
         "labelA",
         "labelB",
-        "ΔpIC50",
-        "uncertainty (ΔpIC50)",
+        "DpIC50",
+        "uncertainty (unitless)",
         "source",
         "computational",
     ]
@@ -383,13 +384,31 @@ def test_to_relative_dataframe_pic50(example_map, dataframe_func):
     exp_ddg = rel_dg[rel_dg["computational"] == False]["DDG (kcal/mol)"].values
     rmse_dg = stats.calculate_rmse(exp_ddg, calc_ddg)
     # same again for pic50
-    calc_dpic50 = rel_pci50[rel_pci50["computational"] == True]["ΔpIC50"].values
-    exp_dpic50 = rel_pci50[rel_pci50["computational"] == False]["ΔpIC50"].values
+    calc_dpic50 = rel_pci50[rel_pci50["computational"] == True]["DpIC50"].values
+    exp_dpic50 = rel_pci50[rel_pci50["computational"] == False]["DpIC50"].values
     rmse_pic50 = stats.calculate_rmse(exp_dpic50, calc_dpic50)
     # convert the error back
     rmse_pic50, _ = conversion.convert_observable(rmse_pic50, "pic50", "dg")
     # we need to use the abs value due to the conversion
     assert rmse_dg == pytest.approx(abs(rmse_pic50), abs=0.01)
+
+
+@pytest.mark.parametrize(
+    "dataframe_func",
+    [
+        pytest.param(lambda fe, observable: fe.get_relative_dataframe(observable_type=observable), id="relative"),
+        pytest.param(lambda fe, observable: fe.get_absolute_dataframe(observable_type=observable), id="absolute"),
+        pytest.param(
+            lambda fe, observable: fe.get_all_to_all_relative_dataframe(symmetrical=False, observable_type=observable),
+            id="all-to-all",
+        ),
+    ],
+)
+def test_to_dataframe_bad_observable(example_map, dataframe_func):
+    """Make sure an error is raised if we request the dataframe in an unsupported observable type."""
+    example_map.generate_absolute_values()
+    with pytest.raises(ValueError, match="Unknown observable_type: 'unsupported'"):
+        dataframe_func(example_map, "unsupported")
 
 
 def test_to_absolute_dataframe_regression(example_map):
@@ -416,7 +435,7 @@ def test_to_absolute_dataframe_pic50(example_map):
     assert abs_dg.shape == abs_pci50.shape
 
     # make sure the column order is the same but the names have been updated
-    assert abs_pci50.columns.tolist() == ["label", "pIC50", "uncertainty (pIC50)", "source", "computational"]
+    assert abs_pci50.columns.tolist() == ["label", "pIC50", "uncertainty (unitless)", "source", "computational"]
 
     # as dg to pic50 is linear check the RMSE also converts
     calc_ddg = abs_dg[abs_dg["computational"] == True]["DG (kcal/mol)"].values
@@ -531,20 +550,39 @@ def test_all_to_all_pairwise_df_absolute(example_map):
     )
 
 
-def test_all_to_all_pairwise_df_no_data():
+@pytest.mark.parametrize("observable, value, uncertainty", [
+    pytest.param("dg", "DDG (kcal/mol)", "uncertainty (kcal/mol)", id="dg"),
+    pytest.param("pic50", "DpIC50", "uncertainty (unitless)", id="pic50"),
+])
+def test_all_to_all_pairwise_df_no_data(observable, value, uncertainty):
     """Test that we can generate the all-to-all pairwise dataframe with no data without error."""
     fe_map = femap.FEMap()
-    df = fe_map.get_all_to_all_relative_dataframe(symmetrical=False)
+    df = fe_map.get_all_to_all_relative_dataframe(symmetrical=False, observable_type=observable)
     assert len(df) == 0
     # make sure the columns are still correct though
     assert df.columns.tolist() == [
         "labelA",
         "labelB",
-        "DDG (kcal/mol)",
-        "uncertainty (kcal/mol)",
+        value,
+        uncertainty,
         "source",
         "computational",
     ]
+
+
+def test_missing_column_names_when_converting(example_map):
+    """Make sure a clear error is raised if we try and convert to a dataframe but the column names are missing."""
+    # try and convert the wrong dataframe
+    rel_df = example_map.get_relative_dataframe()
+    with pytest.raises(ValueError, match=re.escape("Column(s) ['DG (kcal/mol)'] not found in dataframe.")):
+        femap._convert_dg_df_to_pic50(
+            df=rel_df,
+            value_col="DG (kcal/mol)",
+            uncertainty_col="uncertainty (kcal/mol)",
+            new_value_col="pIC50",
+            new_uncertainty_col="uncertainty (unitless)",
+            temperature=298.15 * unit.kelvin,
+        )
 
 
 def test_to_all_pairwise_df_uses_covariance_matrix():

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -397,8 +397,8 @@ def test_to_absolute_dataframe_regression(example_map):
     example_map.generate_absolute_values()
     abs_df = example_map.get_absolute_dataframe()
     # make sure the RMSE and R2 matches some historic data
-    calc_dg = abs_df[abs_df["computational"] == True]["DG (kcal/mol)"].values
-    exp_dg = abs_df[abs_df["computational"] == False]["DG (kcal/mol)"].values
+    calc_dg = abs_df[abs_df["computational"] == True]["DG (kcal/mol)"].to_numpy(copy=True)
+    exp_dg = abs_df[abs_df["computational"] == False]["DG (kcal/mol)"].to_numpy(copy=True)
     # as the MLE values are centered at zero apply a shift to the experimental mean
     calc_dg -= calc_dg.mean()  # remove any systematic shift
     calc_dg += exp_dg.mean()

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -1,5 +1,5 @@
-import re
 import json
+import re
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -550,10 +550,13 @@ def test_all_to_all_pairwise_df_absolute(example_map):
     )
 
 
-@pytest.mark.parametrize("observable, value, uncertainty", [
-    pytest.param("dg", "DDG (kcal/mol)", "uncertainty (kcal/mol)", id="dg"),
-    pytest.param("pic50", "DpIC50", "uncertainty (unitless)", id="pic50"),
-])
+@pytest.mark.parametrize(
+    "observable, value, uncertainty",
+    [
+        pytest.param("dg", "DDG (kcal/mol)", "uncertainty (kcal/mol)", id="dg"),
+        pytest.param("pic50", "DpIC50", "uncertainty (unitless)", id="pic50"),
+    ],
+)
 def test_all_to_all_pairwise_df_no_data(observable, value, uncertainty):
     """Test that we can generate the all-to-all pairwise dataframe with no data without error."""
     fe_map = femap.FEMap()

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -8,8 +8,7 @@ import pytest
 from openff.units import unit
 
 import cinnabar
-from cinnabar import estimators, femap
-from cinnabar import stats, conversion
+from cinnabar import conversion, estimators, femap, stats
 
 
 def test_read_csv(example_csv):
@@ -332,18 +331,11 @@ def test_generate_absolute_values_repeats():
 
 
 @pytest.mark.parametrize(
-    "dataframe_func, expected", [
-        pytest.param(
-            lambda fe: fe.get_relative_dataframe(),
-            1.05,
-            id="relative"
-        ),
-        pytest.param(
-            lambda fe: fe.get_all_to_all_relative_dataframe(symmetrical=False),
-            1.21,
-            id="all-to-all"
-        )
-    ]
+    "dataframe_func, expected",
+    [
+        pytest.param(lambda fe: fe.get_relative_dataframe(), 1.05, id="relative"),
+        pytest.param(lambda fe: fe.get_all_to_all_relative_dataframe(symmetrical=False), 1.21, id="all-to-all"),
+    ],
 )
 def test_to_relative_dataframe_regression(example_map, dataframe_func, expected):
     """Test that the values in the relative/pairwise relative dataframe match the original values in the map."""
@@ -359,17 +351,15 @@ def test_to_relative_dataframe_regression(example_map, dataframe_func, expected)
 
 
 @pytest.mark.parametrize(
-    "dataframe_func", [
-        pytest.param(
-            lambda fe, observable: fe.get_relative_dataframe(observable_type=observable),
-            id="relative"
-        ),
+    "dataframe_func",
+    [
+        pytest.param(lambda fe, observable: fe.get_relative_dataframe(observable_type=observable), id="relative"),
         pytest.param(
             # we need the abs values for the all-to-all method
             lambda fe, observable: fe.get_all_to_all_relative_dataframe(symmetrical=False, observable_type=observable),
-            id="all-to-all"
-        )
-    ]
+            id="all-to-all",
+        ),
+    ],
 )
 def test_to_relative_dataframe_pic50(example_map, dataframe_func):
     """Test that returning the values in units of pIC50 gives error metrics consistent with the values in kcal/mol"""
@@ -379,7 +369,14 @@ def test_to_relative_dataframe_pic50(example_map, dataframe_func):
     assert rel_dg.shape == rel_pci50.shape
 
     # make sure the column order is the same but the names have been updated
-    assert rel_pci50.columns.tolist() == ["labelA", "labelB", "ΔpIC50", "uncertainty (ΔpIC50)", "source", "computational"]
+    assert rel_pci50.columns.tolist() == [
+        "labelA",
+        "labelB",
+        "ΔpIC50",
+        "uncertainty (ΔpIC50)",
+        "source",
+        "computational",
+    ]
 
     # as dg to pic50 is linear check the RMSE also converts
     calc_ddg = rel_dg[rel_dg["computational"] == True]["DDG (kcal/mol)"].values
@@ -419,8 +416,7 @@ def test_to_absolute_dataframe_pic50(example_map):
     assert abs_dg.shape == abs_pci50.shape
 
     # make sure the column order is the same but the names have been updated
-    assert abs_pci50.columns.tolist() == ["label", "pIC50", "uncertainty (pIC50)", "source",
-                                          "computational"]
+    assert abs_pci50.columns.tolist() == ["label", "pIC50", "uncertainty (pIC50)", "source", "computational"]
 
     # as dg to pic50 is linear check the RMSE also converts
     calc_ddg = abs_dg[abs_dg["computational"] == True]["DG (kcal/mol)"].values

--- a/cinnabar/tests/test_femap.py
+++ b/cinnabar/tests/test_femap.py
@@ -9,6 +9,7 @@ from openff.units import unit
 
 import cinnabar
 from cinnabar import estimators, femap
+from cinnabar import stats, conversion
 
 
 def test_read_csv(example_csv):
@@ -328,6 +329,115 @@ def test_generate_absolute_values_repeats():
     )
     with pytest.raises(ValueError, match="Multiple edges detected between nodes ligA and ligB."):
         fe_map.generate_absolute_values()
+
+
+@pytest.mark.parametrize(
+    "dataframe_func, expected", [
+        pytest.param(
+            lambda fe: fe.get_relative_dataframe(),
+            1.05,
+            id="relative"
+        ),
+        pytest.param(
+            lambda fe: fe.get_all_to_all_relative_dataframe(symmetrical=False),
+            1.21,
+            id="all-to-all"
+        )
+    ]
+)
+def test_to_relative_dataframe_regression(example_map, dataframe_func, expected):
+    """Test that the values in the relative/pairwise relative dataframe match the original values in the map."""
+    # needed for the pairwise dataframe
+    example_map.generate_absolute_values()
+    rel_df = dataframe_func(example_map)
+    # calculate the RMSE between the reported edges and the experimental differences
+    # make sure this matches some historic data
+    calc_ddg = rel_df[rel_df["computational"] == True]["DDG (kcal/mol)"].values
+    exp_ddg = rel_df[rel_df["computational"] == False]["DDG (kcal/mol)"].values
+    rmse = stats.calculate_rmse(exp_ddg, calc_ddg)
+    assert rmse == pytest.approx(expected, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    "dataframe_func", [
+        pytest.param(
+            lambda fe, observable: fe.get_relative_dataframe(observable_type=observable),
+            id="relative"
+        ),
+        pytest.param(
+            # we need the abs values for the all-to-all method
+            lambda fe, observable: fe.get_all_to_all_relative_dataframe(symmetrical=False, observable_type=observable),
+            id="all-to-all"
+        )
+    ]
+)
+def test_to_relative_dataframe_pic50(example_map, dataframe_func):
+    """Test that returning the values in units of pIC50 gives error metrics consistent with the values in kcal/mol"""
+    example_map.generate_absolute_values()
+    rel_dg = dataframe_func(example_map, "dg")
+    rel_pci50 = dataframe_func(example_map, "pic50")
+    assert rel_dg.shape == rel_pci50.shape
+
+    # make sure the column order is the same but the names have been updated
+    assert rel_pci50.columns.tolist() == ["labelA", "labelB", "ΔpIC50", "uncertainty (ΔpIC50)", "source", "computational"]
+
+    # as dg to pic50 is linear check the RMSE also converts
+    calc_ddg = rel_dg[rel_dg["computational"] == True]["DDG (kcal/mol)"].values
+    exp_ddg = rel_dg[rel_dg["computational"] == False]["DDG (kcal/mol)"].values
+    rmse_dg = stats.calculate_rmse(exp_ddg, calc_ddg)
+    # same again for pic50
+    calc_dpic50 = rel_pci50[rel_pci50["computational"] == True]["ΔpIC50"].values
+    exp_dpic50 = rel_pci50[rel_pci50["computational"] == False]["ΔpIC50"].values
+    rmse_pic50 = stats.calculate_rmse(exp_dpic50, calc_dpic50)
+    # convert the error back
+    rmse_pic50, _ = conversion.convert_observable(rmse_pic50, "pic50", "dg")
+    # we need to use the abs value due to the conversion
+    assert rmse_dg == pytest.approx(abs(rmse_pic50), abs=0.01)
+
+
+def test_to_absolute_dataframe_regression(example_map):
+    """Test that the values in the absolute dataframe match the original values in the map."""
+    example_map.generate_absolute_values()
+    abs_df = example_map.get_absolute_dataframe()
+    # make sure the RMSE and R2 matches some historic data
+    calc_dg = abs_df[abs_df["computational"] == True]["DG (kcal/mol)"].values
+    exp_dg = abs_df[abs_df["computational"] == False]["DG (kcal/mol)"].values
+    # as the MLE values are centered at zero apply a shift to the experimental mean
+    calc_dg -= calc_dg.mean()  # remove any systematic shift
+    calc_dg += exp_dg.mean()
+    rmse = stats.calculate_rmse(exp_dg, calc_dg)
+    assert rmse == pytest.approx(0.84, abs=0.01)
+    r_2 = stats.calculate_r2(exp_dg, calc_dg)
+    assert r_2 == pytest.approx(0.61, abs=0.01)
+
+
+def test_to_absolute_dataframe_pic50(example_map):
+    """Test that returning the values in units of pIC50 gives error metrics consistent with the values in kcal/mol"""
+    example_map.generate_absolute_values()
+    abs_dg = example_map.get_absolute_dataframe()
+    abs_pci50 = example_map.get_absolute_dataframe(observable_type="pic50")
+    assert abs_dg.shape == abs_pci50.shape
+
+    # make sure the column order is the same but the names have been updated
+    assert abs_pci50.columns.tolist() == ["label", "pIC50", "uncertainty (pIC50)", "source",
+                                          "computational"]
+
+    # as dg to pic50 is linear check the RMSE also converts
+    calc_ddg = abs_dg[abs_dg["computational"] == True]["DG (kcal/mol)"].values
+    exp_ddg = abs_dg[abs_dg["computational"] == False]["DG (kcal/mol)"].values
+    rmse_dg = stats.calculate_rmse(exp_ddg, calc_ddg)
+    # same again for pic50
+    calc_dpic50 = abs_pci50[abs_pci50["computational"] == True]["pIC50"].values
+    exp_dpic50 = abs_pci50[abs_pci50["computational"] == False]["pIC50"].values
+    rmse_pic50 = stats.calculate_rmse(exp_dpic50, calc_dpic50)
+    # convert the error back
+    rmse_pic50, _ = conversion.convert_observable(rmse_pic50, "pic50", "dg")
+    # we need to use the abs value due to the conversion
+    assert rmse_dg == pytest.approx(abs(rmse_pic50), abs=0.01)  # use abs 0.01 as we round pic50 to 2dp
+    # also check the ranking
+    r_2_dg = stats.calculate_r2(exp_ddg, calc_ddg)
+    r_2_pic50 = stats.calculate_r2(exp_dpic50, calc_dpic50)
+    assert r_2_dg == pytest.approx(r_2_pic50, abs=0.01)  # use abs 0.01 as we round pic50 to 2dp
 
 
 def test_to_dataframe(example_map):

--- a/news/pic50_dataframes.rst
+++ b/news/pic50_dataframes.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* The ``get_relative/absolute/all_to_all_relative_dataframe()`` functions can now return values as ``pIC50``. This is controlled by passing ``observable_type="pic50"`` `PR#208 <https://github.com/OpenFreeEnergy/cinnabar/pull/208>`_.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This is work towards custom units on plots, we now allow users to select the dataframes to be in DG (kcal/mol) or pIC50 a common unit used in drug discovery. 

After this we plan on reworking all plotting functions to use the dataframes internally, which should allow users to easily swap the reported units, see #206 as an example for the ecdf plots.

This PR also includes the relative dataframe fix from #206

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Checklist
- [x] Added a ``news`` entry for new features, bug fixes, or other user facing changes.

## Status
- [x] Ready to go

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.
